### PR TITLE
Preserve document encoding and BOM usage

### DIFF
--- a/src/XliffTasks/Model/Document.cs
+++ b/src/XliffTasks/Model/Document.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 
 namespace XliffTasks.Model
 {
@@ -12,6 +13,15 @@ namespace XliffTasks.Model
         /// Indicates if content has been loaded in to the document.
         /// </summary>
         public abstract bool HasContent { get; }
+
+        private static Encoding s_utf8WithBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        private static Encoding s_utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        /// <summary>
+        /// The encoding to use when saving the document to a stream.
+        /// This is the encoding that was detected on Load, or default value of UTF8-with-BOM for new documents.
+        /// </summary>
+        public Encoding Encoding { get; set; } = s_utf8WithBom;
 
         /// <summary>
         /// Loads (or reloads) the document content from the given file path.
@@ -29,9 +39,16 @@ namespace XliffTasks.Model
         /// </summary>
         public void Load(Stream stream)
         {
-            using (var reader = new StreamReader(stream))
+            // NOTE: It is important to pass UTF8-without-BOM here and not UTF8-with-BOM (aka Encoding.UTF8 and also same
+            // as default when not passing encoding). The reason is that CurrentEncoding is only different from the encoding 
+            // provided when the StreamReader encounters a BOM. As such, if we start off with UTF8-with-BOM, we'll end up with 
+            // UTF8-with-BOM even if the document has no BOM, which would defeat our purpose of preserving the encoding and BOM
+            // of the original document in a Load/Modify/Save cycle.
+
+            using (var reader = new StreamReader(stream, s_utf8WithoutBom, detectEncodingFromByteOrderMarks: true))
             {
                 Load(reader);
+                Encoding = reader.CurrentEncoding;
             }
         }
 
@@ -60,7 +77,7 @@ namespace XliffTasks.Model
         {
             EnsureContent();
 
-            using (var writer = new StreamWriter(stream))
+            using (var writer = new StreamWriter(stream, Encoding))
             {
                 Save(writer);
             }


### PR DESCRIPTION
Also, remove unnecessary empty group on xlf update