### PR TITLE
Fix incorrect placement of notes on initial node creation

### DIFF
--- a/src/XliffTasks.Tests/XlfDocumentTests.cs
+++ b/src/XliffTasks.Tests/XlfDocumentTests.cs
@@ -36,12 +36,14 @@ namespace XliffTasks.Tests
 @"<root>
   <data name=""Hello"">
     <value>Hello!</value>
+    <comment>Greeting</comment>
   </data>
   <data name=""Goodbye"">
     <value>Goodbye!</value>
   </data>
   <data name=""Apple"">
    <value>Apple</value>
+   <comment>Tasty</comment>
   </data>
 </root>";
 
@@ -52,7 +54,7 @@ namespace XliffTasks.Tests
       <trans-unit id=""Hello"">
         <source>Hello!</source>
         <target state=""new"">Hello!</target>
-        <note />
+        <note>Greeting</note>
       </trans-unit>
       <trans-unit id=""Goodbye"">
         <source>Goodbye!</source>
@@ -62,7 +64,7 @@ namespace XliffTasks.Tests
       <trans-unit id=""Apple"">
         <source>Apple</source>
         <target state=""new"">Apple</target>
-        <note />
+        <note>Tasty</note>
       </trans-unit>
     </body>
   </file>
@@ -77,7 +79,7 @@ namespace XliffTasks.Tests
       <trans-unit id=""Hello"">
         <source>Hello!</source>
         <target state=""translated"">Bonjour!</target>
-        <note />
+        <note>Greeting</note>
       </trans-unit>
       <trans-unit id=""Goodbye"">
         <source>Goodbye!</source>
@@ -87,7 +89,7 @@ namespace XliffTasks.Tests
       <trans-unit id=""Apple"">
         <source>Apple</source>
         <target state=""translated"">Apple</target>
-        <note />
+        <note>Tasty</note>
       </trans-unit>
     </body>
   </file>

--- a/src/XliffTasks/Model/XlfDocument.cs
+++ b/src/XliffTasks/Model/XlfDocument.cs
@@ -162,7 +162,7 @@ namespace XliffTasks.Model
                         new XAttribute("id", sourceNode.Id),
                         new XElement(ns + "source", sourceNode.Source),
                         new XElement(ns + "target", new XAttribute("state", "new"), sourceNode.Source),
-                        new XElement(ns + "note"), sourceNode.Note));
+                        new XElement(ns + "note", sourceNode.Note == "" ? null : sourceNode.Note)));
 
                 changed = true;
             }


### PR DESCRIPTION
Fix #26 

@tmat Note that you'll need to delete and regenerate the roslyn-analyzers files because this does not attempt to fix up documents already corrupted by the bug.