### PR TITLE
Use write temp and replace to avoid 2 processes working on the same x…

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,7 @@ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 New-Item -Type Directory -Force $DotnetInstallDir  | Out-Null
 New-Item -Type Directory -Force $LogDir | Out-Null
 
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.ps1" -OutFile "$DotnetInstallDir\dotnet-install.ps1"
+Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.sh" -OutFile "$DotnetInstallDir\dotnet-install.ps1"
 & $DotnetInstallDir/dotnet-install.ps1 -Version "2.0.0" -InstallDir "$DotnetInstallDir"
 
 $env:PATH="$DotnetInstallDir;$env:PATH"

--- a/build.ps1
+++ b/build.ps1
@@ -30,8 +30,8 @@ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 New-Item -Type Directory -Force $DotnetInstallDir  | Out-Null
 New-Item -Type Directory -Force $LogDir | Out-Null
 
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile "$DotnetInstallDir\dotnet-install.ps1"
-& $DotnetInstallDir/dotnet-install.ps1 -Version "1.0.1" -InstallDir "$DotnetInstallDir"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.ps1" -OutFile "$DotnetInstallDir\dotnet-install.ps1"
+& $DotnetInstallDir/dotnet-install.ps1 -Version "2.0.0" -InstallDir "$DotnetInstallDir"
 
 $env:PATH="$DotnetInstallDir;$env:PATH"
 

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 mkdir -p $DOTNET_INSTALL_DIR
 mkdir -p $LOG_DIR
 
-curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --install-dir $DOTNET_INSTALL_DIR --version 1.0.1
+curl -sSL https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --install-dir $DOTNET_INSTALL_DIR --version 2.0.0
 
 PATH="$DOTNET_INSTALL_DIR:$PATH"
 

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 mkdir -p $DOTNET_INSTALL_DIR
 mkdir -p $LOG_DIR
 
-curl -sSL https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --install-dir $DOTNET_INSTALL_DIR --version 2.0.0
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir $DOTNET_INSTALL_DIR --version 2.0.0
 
 PATH="$DOTNET_INSTALL_DIR:$PATH"
 

--- a/src/XliffTasks.Tests/XliffTasks.Tests.csproj
+++ b/src/XliffTasks.Tests/XliffTasks.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/XliffTasks/ExponentialRetry.cs
+++ b/src/XliffTasks/ExponentialRetry.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XliffTasks
+{
+    public class ExponentialRetry
+    {
+        public static IEnumerable<TimeSpan> Intervals
+        {
+            get
+            {
+                var seconds = 5;
+                while (true)
+                {
+                    yield return TimeSpan.FromSeconds(seconds);
+                    seconds *= 2;
+                }
+            }
+        }
+
+        public static async Task ExecuteWithRetry<T>(Func<T> action,
+            Func<T, bool> isSuccess,
+            int maxRetryCount,
+            Func<IEnumerable<Task>> timer,
+            string taskDescription = "")
+        {
+            var count = 0;
+            foreach (var t in timer())
+            {
+                await t;
+                var result = action();
+                if (isSuccess(result))
+                    return;
+                count++;
+                if (count == maxRetryCount)
+                    throw new RetryFailedException(
+                        $"Retry failed for {taskDescription} after {count} times with result: {result}");
+            }
+            throw new Exception("Timer should not be exhausted");
+        }
+
+        public static IEnumerable<Task> Timer(IEnumerable<TimeSpan> interval)
+        {
+            return interval.Select(Task.Delay);
+        }
+    }
+}

--- a/src/XliffTasks/XliffTasks.csproj
+++ b/src/XliffTasks/XliffTasks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
     <EnableDefaultItems>false</EnableDefaultItems>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/src/XliffTasks/XliffTasks.csproj
+++ b/src/XliffTasks/XliffTasks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
     <EnableDefaultItems>false</EnableDefaultItems>
@@ -14,10 +14,10 @@
     <Content Include="buildCrossTargeting\*" PackagePath="buildCrossTargeting" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.App" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
@@ -27,6 +27,10 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Tasks\applesauce.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
…lf file

To use File.Replace need to update to netcoreapp2.0

Use FileShare.None in Document.Save(path) and FileShare.Read in Document.Load(path)

Reply might be needed, however, when test on Roslyn, no concurrency issue happened.

This maximize parallelism and get rid of the need to create 1:1 mutex:file, eliminating the naming problem and other things we may be missing here such as handling AbandonedMutexException.
On Windows:
Readers will prevent the file from being overwritten due to FileShare.Read.
Readers can read in parallel, but when there's contention with a writer
On Unix:
FileShare.Read does nothing, but...
File.Replace is implemented with rename system call that will mean that even though writers can overwrite while

reading is happening, each reader will see file before or after overwrite, not in between, which is the same reader-writer semantic we want.