### PR TITLE
enable generating .xlf files from <EmbeddedResource> elements added during the build

### DIFF
--- a/src/XliffTasks/Tasks/GatherXlf.cs
+++ b/src/XliffTasks/Tasks/GatherXlf.cs
@@ -31,11 +31,11 @@ namespace XliffTasks.Tasks
 
             foreach (var source in Sources)
             {
-                string sourcePath = source.ItemSpec;
+                string sourceDocumentPath = source.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, source.ItemSpec);
 
                 foreach (var language in Languages)
                 {
-                    string xlfPath = GetXlfPath(sourcePath, language);
+                    string xlfPath = GetXlfPath(sourceDocumentPath, language);
                     var xlf = new TaskItem(source) { ItemSpec = xlfPath };
                     xlf.SetMetadata(MetadataKey.XlfSource, source.ItemSpec);
                     xlf.SetMetadata(MetadataKey.XlfTranslatedFullPath, GetTranslatedOutputPath(source, language, outputPaths));
@@ -57,13 +57,14 @@ namespace XliffTasks.Tasks
                 source.SetMetadata(MetadataKey.XlfTranslatedFilename, translatedFilename);
             }
 
+            string sourceDocumentPath = source.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, source.ItemSpec);
             string extension = Path.GetExtension(source.ItemSpec);
             string outputPath = Path.Combine(TranslatedOutputDirectory, $"{translatedFilename}.{language}{extension}");
 
             if (!outputPaths.Add(outputPath))
             {
                 throw new BuildErrorException(
-                    $"Two or more source files to be translated in the same project are named {Path.GetFileName(source.ItemSpec)}. " +
+                    $"Two or more source files to be translated in the same project are named {Path.GetFileName(sourceDocumentPath)}. " +
                     $"Give them unique names or set unique {MetadataKey.XlfTranslatedFilename} metadata.");
             }
 

--- a/src/XliffTasks/Tasks/MetadataKey.cs
+++ b/src/XliffTasks/Tasks/MetadataKey.cs
@@ -9,6 +9,7 @@ namespace XliffTasks
         public const string Link = nameof(Link);
         public const string LogicalName = nameof(LogicalName);
         public const string ManifestResourceName = nameof(ManifestResourceName);
+        public const string SourceDocumentPath = nameof(SourceDocumentPath);
         public const string XlfLanguage = nameof(XlfLanguage);
         public const string XlfSource = nameof(XlfSource);
         public const string XlfSourceFormat = nameof(XlfSourceFormat);

--- a/src/XliffTasks/Tasks/TaskItemExtensions.cs
+++ b/src/XliffTasks/Tasks/TaskItemExtensions.cs
@@ -18,5 +18,17 @@ namespace XliffTasks.Tasks
 
             return value;
         }
+
+        public static string GetMetadataOrDefault(this ITaskItem item, string key, string defaultValue)
+        {
+            string value = item.GetMetadata(key);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            return value;
+        }
     }
 }

--- a/src/XliffTasks/Tasks/UpdateXlf.cs
+++ b/src/XliffTasks/Tasks/UpdateXlf.cs
@@ -29,13 +29,14 @@ namespace XliffTasks.Tasks
             foreach (var item in Sources)
             {
                 string sourcePath = item.ItemSpec;
+                string sourceDocumentPath = item.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, item.ItemSpec);
                 string sourceFormat = item.GetMetadataOrThrow(MetadataKey.XlfSourceFormat);
                 TranslatableDocument sourceDocument = LoadSourceDocument(sourcePath, sourceFormat);
                 string sourceDocumentId = GetSourceDocumentId(sourcePath);
 
                 foreach (var language in Languages)
                 {
-                    string xlfPath = GetXlfPath(sourcePath, language);
+                    string xlfPath = GetXlfPath(sourceDocumentPath, language);
                     XlfDocument xlfDocument;
 
                     try

--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -15,18 +15,6 @@
   <UsingTask TaskName="TranslateSource" AssemblyFile="$(XliffTasksAssembly)" />
   <UsingTask TaskName="UpdateXlf" AssemblyFile="$(XliffTasksAssembly)" />
 
-  <ItemGroup>
-    <EmbeddedResource Update="@(EmbeddedResource)">
-      <XlfInput Condition="'%(XlfInput)' == '' and '%(Extension)' == '.resx'">true</XlfInput>
-    </EmbeddedResource>
-
-    <XlfSource Include="@(EmbeddedResource->WithMetadataValue('XlfInput', 'true'))" />
-    <XlfSource Include="@(VSCTCompile->WithMetadataValue('XlfInput', 'true'))" />
-    <XlfSource Include="@(XamlPropertyRule->WithMetadataValue('XlfInput', 'true'))" />
-    <XlfSource Include="@(XamlPropertyRuleNoCodeBehind->WithMetadataValue('XlfInput', 'true'))" />
-    <XlfSource Include="@(XamlPropertyProjectItemsSchema->WithMetadataValue('XlfInput', 'true'))" />
-  </ItemGroup>
-
   <!--
     Note that .xlf files are source files, not build outputs. We therefore cannot use their modification time
     to drive incremental build. It is possible for .xlf files to be out-of-sync with their source
@@ -51,7 +39,8 @@
   </PropertyGroup>
 
   <!-- Updates the list of XlfSource items that drives incremental update (see above) -->
-  <Target Name="UpdateXlfSourceList">
+  <Target Name="UpdateXlfSourceList"
+          DependsOnTargets="GetXlfSources">
     <MakeDir Directories="$(XlfIntermediateOutputPath)" />
 
     <WriteLinesToFile File="$(_XlfSourceList)"
@@ -109,10 +98,22 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GetXlfSources" Returns="@(XlfSource)" />
+  <Target Name="GetXlfSources" Returns="@(XlfSource)">
+    <ItemGroup>
+      <EmbeddedResource Update="@(EmbeddedResource)">
+        <XlfInput Condition="'%(EmbeddedResource.XlfInput)' == '' and '%(EmbeddedResource.Extension)' == '.resx'">true</XlfInput>
+      </EmbeddedResource>
+
+      <XlfSource Include="@(EmbeddedResource->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(VSCTCompile->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(XamlPropertyRule->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(XamlPropertyRuleNoCodeBehind->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(XamlPropertyProjectItemsSchema->WithMetadataValue('XlfInput', 'true'))" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="GatherXlf" 
-          DependsOnTargets="EnsureXlfIsUpToDate"
+          DependsOnTargets="GetXlfSources;EnsureXlfIsUpToDate"
           >
     <GatherXlf Sources="@(XlfSource)"
                Languages="$(XlfLanguages)"


### PR DESCRIPTION
Projects in the F# repo dynamically generate `<EmbeddedResource>` elements as part of a build task and that causes two specific issues that are addressed here:

1. The generated `<EmbeddedResource>` elements don't exist in the project file so the inclusion of those into the `<XlfSource>` collection can't happen at the time that `XliffTasks.targets` is imported.  The solution to this is to simply move the gathering of the sources into the `GetXlfSources` target.  (Fixes #17)
2. The F# build generates `.resx` files into the `obj\` directory which means the generated `xlf\*.xlf` files are also dropped in the `obj\` directory which means they're not included in the source tree.  The solution to this was to honor an optional metadata value `EmbeddedResource.SourceDocumentPath` which is used to then compute the location of the `xlf\` directory.  The F# build sets this metadata value appropriately, but in cases where it's not set (e.g., when the project file has a standard `<EmbeddedResource>` element) then the `xlf\` directory is still based on the location of the `.resx` file as before.