### PR TITLE
ensure .vsct files are translated before allowing the VSSDK to compile them

### DIFF
--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -126,7 +126,7 @@
   <Target Name="TranslateSourceFromXlf"
           Condition="'$(EnableXlfLocalization)' == 'true'"
           DependsOnTargets="GatherXlf;BatchTranslateSourceFromXlf"
-          BeforeTargets="PrepareResourceNames;$(PrepareResourceNamesDependsOn)"
+          BeforeTargets="VSCTCompile;PrepareResourceNames;$(PrepareResourceNamesDependsOn)"
           >
     <GatherTranslatedSource XlfFiles="@(Xlf)" Condition="'@(Xlf)' != ''">
       <Output TaskParameter="Outputs" ItemName="%(Xlf.XlfOutputItem)" />


### PR DESCRIPTION
If the project contains `VSCTCompile` items, those are expected to be passed to the `VSCTCompile` target in the VSSDK, but the [`GatherTranslatedSource` task](https://github.com/dotnet/xliff-tasks/blob/64820755d3a7cdc41077c8908755540eb4175040/src/XliffTasks/build/XliffTasks.targets#L132) augments that group (because [`XlfOutputItem` == "VSCTCompile"](https://github.com/dotnet/xliff-tasks/blob/64820755d3a7cdc41077c8908755540eb4175040/src/XliffTasks/build/XliffTasks.props#L44)) which means the `VSCTCompile` target must be executed _after_ `GatherTranslatedSource` has been run.

To ensure this doesn't break projects that don't reference the VSSDK, I tested it by also adding `SomeTargetNameThatDoesntExist` to the `BeforeTargets` group, which means if the `VSCTCompile` target isn't defined nothing bad will happen.