### PR TITLE
Enable .xlf translations for unstructured documents and VS templates.

### DIFF
--- a/src/XliffTasks.Tests/UnstructuredDocumentTests.cs
+++ b/src/XliffTasks.Tests/UnstructuredDocumentTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using XliffTasks.Model;
+using Xunit;
+
+namespace XliffTasks.Tests
+{
+    public class UnstructuredDocumentTests
+    {
+        [Fact]
+        public void BasicLoadAndTranslate()
+        {
+            string source =
+@"
+Say hello: @@@idhello|Hello@@@<end>
+Say goodbye: @@@idgoodbye|Goodbye@@@<end>
+";
+
+            var translations = new Dictionary<string, string>
+            {
+                ["idhello"] = "Bonjour!",
+                ["idgoodbye"] = "Au revoir!",
+            };
+
+            string expectedTranslation =
+@"
+Say hello: Bonjour!<end>
+Say goodbye: Au revoir!<end>
+";
+
+            var document = new UnstructuredDocument();
+            var writer = new StringWriter();
+            document.Load(new StringReader(source));
+            document.Translate(translations);
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
+
+        [Fact]
+        public void SourceEndsWithTranslatableSpan()
+        {
+            string source = "@@@idhello|Hello@@@";
+
+            var translations = new Dictionary<string, string>
+            {
+                ["idhello"] = "Bonjour!",
+            };
+
+            string expectedTranslation = "Bonjour!";
+
+            var document = new UnstructuredDocument();
+            var writer = new StringWriter();
+            document.Load(new StringReader(source));
+            document.Translate(translations);
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
+    }
+}

--- a/src/XliffTasks/Model/UnstructuredDocument.cs
+++ b/src/XliffTasks/Model/UnstructuredDocument.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace XliffTasks.Model
+{
+    internal sealed class UnstructuredDocument : TranslatableDocument
+    {
+        const string TranslatableSpanMarker = "@@@";
+        const string TranslatableSpanSeparator = "|";
+
+        private List<string> _fragments = new List<string>();
+        private List<UnstructuredTranslatableNode> _nodes = new List<UnstructuredTranslatableNode>();
+
+        protected override IEnumerable<TranslatableNode> GetTranslatableNodes()
+        {
+            return _nodes;
+        }
+
+        protected override void LoadCore(TextReader reader)
+        {
+            var text = reader.ReadToEnd();
+            var lastSpanEnd = 0;
+            var spanStart = text.IndexOf(TranslatableSpanMarker);
+            while (spanStart >= 0)
+            {
+                // the previous span of text is untranslatable and is simply copied
+                var plainSpan = text.Substring(lastSpanEnd, spanStart - lastSpanEnd);
+                _fragments.Add(plainSpan);
+
+                // next, find the translatable span
+                lastSpanEnd = text.IndexOf(TranslatableSpanMarker, spanStart + 1);
+                if (lastSpanEnd < 0)
+                {
+                    throw new InvalidOperationException($"No end of span marker '{TranslatableSpanMarker}' found.");
+                }
+
+                lastSpanEnd += TranslatableSpanMarker.Length; // account for the length of the end marker
+                var spanLength = lastSpanEnd - spanStart - TranslatableSpanMarker.Length * 2; // trim off the marker start/end length
+                var translatableSpan = text.Substring(spanStart + TranslatableSpanMarker.Length, spanLength);
+                var separatorIndex = translatableSpan.IndexOf(TranslatableSpanSeparator);
+                if (separatorIndex < 0)
+                {
+                    throw new InvalidOperationException($"No span separator '{TranslatableSpanSeparator}' found.");
+                }
+
+                var id = translatableSpan.Substring(0, separatorIndex);
+                var source = translatableSpan.Substring(separatorIndex + TranslatableSpanSeparator.Length);
+
+                // keep the original span's text
+                _nodes.Add(new UnstructuredTranslatableNode(_fragments, _fragments.Count, id, source));
+                _fragments.Add(source);
+
+                spanStart = lastSpanEnd >= text.Length
+                    ? -1 // don't search beyond the end of the text
+                    : text.IndexOf(TranslatableSpanMarker, lastSpanEnd + 1);
+            }
+
+            if (lastSpanEnd < text.Length)
+            {
+                // add final span
+                _fragments.Add(text.Substring(lastSpanEnd));
+            }
+        }
+
+        protected override void SaveCore(TextWriter writer)
+        {
+            foreach (var fragment in _fragments)
+            {
+                writer.Write(fragment);
+            }
+        }
+
+        private sealed class UnstructuredTranslatableNode : TranslatableNode
+        {
+            private IList<string> _fragments;
+            private int _fragmentIndex;
+
+            public UnstructuredTranslatableNode(IList<string> fragments, int fragmentIndex, string id, string source)
+                : base(id, source, null)
+            {
+                _fragments = fragments;
+                _fragmentIndex = fragmentIndex;
+            }
+
+            public override void Translate(string translation)
+            {
+                _fragments[_fragmentIndex] = translation;
+            }
+        }
+    }
+}

--- a/src/XliffTasks/Model/XlfDocument.cs
+++ b/src/XliffTasks/Model/XlfDocument.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using XliffTasks.Tasks;
 
 namespace XliffTasks.Model
 {
@@ -70,7 +71,17 @@ namespace XliffTasks.Model
         public bool Update(TranslatableDocument sourceDocument, string sourceDocumentId)
         {
             bool changed = false;
-            Dictionary<string, TranslatableNode> nodesById = sourceDocument.Nodes.ToDictionary(n => n.Id);
+            var nodesById = new Dictionary<string, TranslatableNode>();
+            foreach (var node in sourceDocument.Nodes)
+            {
+                if (nodesById.ContainsKey(node.Id))
+                {
+                    throw new BuildErrorException($"The document '{sourceDocumentId}' has a duplicate node '{node.Id}'.");
+                }
+
+                nodesById.Add(node.Id, node);
+            }
+
             XNamespace ns = _document.Root.Name.Namespace;
 
             XElement fileElement = _document.Root.Element(ns + "file");

--- a/src/XliffTasks/Tasks/TransformTemplates.cs
+++ b/src/XliffTasks/Tasks/TransformTemplates.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using XliffTasks.Model;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class TransformTemplates : XlfTask
+    {
+        [Required]
+        public ITaskItem[] Templates { get; set; }
+
+        [Required]
+        public ITaskItem[] UnstructuredResources { get; set; }
+
+        [Required]
+        public string[] Languages { get; set; }
+
+        [Required]
+        public string TranslatedOutputDirectory { get; set; }
+
+        [Output]
+        public ITaskItem[] TransformedTemplates { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            var transformedTemplates = new List<ITaskItem>();
+            var resourceMap = UnstructuredResources.ToDictionary(item => item.GetMetadata("FullPath"));
+            foreach (var template in Templates)
+            {
+                // special-case the default template items as the 1033 culture
+                var defaultTemplate = TransformTemplate(template, language: null, resourceMap: null);
+                transformedTemplates.Add(defaultTemplate);
+
+                // and process other languages like normal
+                foreach (var language in Languages)
+                {
+                    var item = TransformTemplate(template, language, resourceMap);
+                    transformedTemplates.Add(item);
+                }
+            }
+
+            TransformedTemplates = transformedTemplates.ToArray();
+        }
+
+        private ITaskItem TransformTemplate(ITaskItem template, string language, IDictionary<string, ITaskItem> resourceMap)
+        {
+            if ((language == null) ^ (resourceMap == null))
+            {
+                throw new ArgumentException($"Either both '{nameof(language)}' and '{nameof(resourceMap)}' must be specified, or they both must be 'null'.");
+            }
+
+            var transformingDefaultTemplate = language == null;
+            var templateCulture = transformingDefaultTemplate ? "1033" : language;
+
+            var templateName = Path.GetFileNameWithoutExtension(template.ItemSpec);
+            var templatePath = template.GetMetadata("FullPath");
+            var templateDirectory = Path.GetDirectoryName(templatePath);
+            var templateXml = XDocument.Load(templatePath);
+
+            // create a copy of the .vstemplate and all files
+            var localizedTemplateDirectory = transformingDefaultTemplate
+                ? Path.Combine(TranslatedOutputDirectory, $"{templateName}.default.1033")
+                : Path.Combine(TranslatedOutputDirectory, $"{templateName}.{language}");
+            Directory.CreateDirectory(localizedTemplateDirectory);
+            var cultureSpecificTemplateFile = Path.Combine(localizedTemplateDirectory, Path.GetFileName(template.ItemSpec));
+            File.Copy(templatePath, cultureSpecificTemplateFile, overwrite: true);
+
+            // copy the template project files
+            foreach (var projectNode in templateXml.Descendants().Where(d => d.Name.LocalName == "Project"))
+            {
+                var projectFileFullPath = Path.Combine(templateDirectory, projectNode.Attribute("File").Value);
+                File.Copy(projectFileFullPath, Path.Combine(localizedTemplateDirectory, Path.GetFileName(projectNode.Attribute("File").Value)), overwrite: true);
+            }
+
+            // copy the template project items
+            foreach (var templateItem in templateXml.Descendants().Where(d => d.Name.LocalName == "ProjectItem"))
+            {
+                var templateItemFullPath = Path.Combine(templateDirectory, templateItem.Value);
+                var templateItemDestinationPath = Path.Combine(localizedTemplateDirectory, templateItem.Value);
+                if (transformingDefaultTemplate)
+                {
+                    // if not localizing anything, simply strip out the translation markers
+                    var document = new UnstructuredDocument();
+                    document.Load(templateItemFullPath);
+                    var defaultTranslation = document.Nodes.ToDictionary(node => node.Id, node => node.Source);
+                    document.Translate(defaultTranslation);
+                    document.Save(templateItemDestinationPath);
+                }
+                else
+                {
+                    // try to localize the template items
+                    if (resourceMap.TryGetValue(templateItemFullPath, out var unstructuredResource))
+                    {
+                        // copy a localized file
+                        var localizedFileName = string.Concat(
+                            Path.GetFileNameWithoutExtension(unstructuredResource.ItemSpec),
+                            ".",
+                            language,
+                            Path.GetExtension(unstructuredResource.ItemSpec));
+                        File.Copy(Path.Combine(TranslatedOutputDirectory, localizedFileName), templateItemDestinationPath, overwrite: true);
+                    }
+                    else
+                    {
+                        // copy the original unaltered file
+                        File.Copy(templateItemFullPath, templateItemDestinationPath, overwrite: true);
+                    }
+                }
+            }
+
+            var item = new TaskItem(cultureSpecificTemplateFile);
+            item.SetMetadata("Culture", templateCulture);
+            return item;
+        }
+    }
+}

--- a/src/XliffTasks/Tasks/XlfTask.cs
+++ b/src/XliffTasks/Tasks/XlfTask.cs
@@ -37,6 +37,10 @@ namespace XliffTasks.Tasks
             {
                 document = new ResxDocument();
             }
+            else if (format.Equals("Unstructured", StringComparison.OrdinalIgnoreCase))
+            {
+                document = new UnstructuredDocument();
+            }
             else if (format.Equals("Vsct", StringComparison.OrdinalIgnoreCase))
             {
                 document = new VsctDocument();

--- a/src/XliffTasks/build/XliffTasks.props
+++ b/src/XliffTasks/build/XliffTasks.props
@@ -38,6 +38,13 @@
       <XlfOutputItem>EmbeddedResource</XlfOutputItem>
     </EmbeddedResource>
 
+    <UnstructuredResource>
+      <Visible>false</Visible>
+      <XlfInput>true</XlfInput>
+      <XlfSourceFormat>Unstructured</XlfSourceFormat>
+      <XlfOutputItem>UnstructuredResourceTranslated</XlfOutputItem>
+    </UnstructuredResource>
+
     <VSCTCompile>
       <XlfInput>true</XlfInput>
       <XlfSourceFormat>Vsct</XlfSourceFormat>

--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -105,6 +105,7 @@
       </EmbeddedResource>
 
       <XlfSource Include="@(EmbeddedResource->WithMetadataValue('XlfInput', 'true'))" />
+      <XlfSource Include="@(UnstructuredResource->WithMetadataValue('XlfInput', 'true'))" />
       <XlfSource Include="@(VSCTCompile->WithMetadataValue('XlfInput', 'true'))" />
       <XlfSource Include="@(XamlPropertyRule->WithMetadataValue('XlfInput', 'true'))" />
       <XlfSource Include="@(XamlPropertyRuleNoCodeBehind->WithMetadataValue('XlfInput', 'true'))" />

--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -12,6 +12,7 @@
 
   <UsingTask TaskName="GatherXlf" AssemblyFile="$(XliffTasksAssembly)" />
   <UsingTask TaskName="GatherTranslatedSource" AssemblyFile="$(XliffTasksAssembly)" />
+  <UsingTask TaskName="TransformTemplates" AssemblyFile="$(XliffTasksAssembly)" />
   <UsingTask TaskName="TranslateSource" AssemblyFile="$(XliffTasksAssembly)" />
   <UsingTask TaskName="UpdateXlf" AssemblyFile="$(XliffTasksAssembly)" />
 
@@ -104,6 +105,8 @@
         <XlfInput Condition="'%(EmbeddedResource.XlfInput)' == '' and '%(EmbeddedResource.Extension)' == '.resx'">true</XlfInput>
       </EmbeddedResource>
 
+      <UnstructuredResource Include="%(VSTemplate.TranslatableResources)" />
+
       <XlfSource Include="@(EmbeddedResource->WithMetadataValue('XlfInput', 'true'))" />
       <XlfSource Include="@(UnstructuredResource->WithMetadataValue('XlfInput', 'true'))" />
       <XlfSource Include="@(VSCTCompile->WithMetadataValue('XlfInput', 'true'))" />
@@ -133,6 +136,26 @@
       <Output TaskParameter="Outputs" ItemName="%(Xlf.XlfOutputItem)" />
       <Output TaskParameter="Outputs" ItemName="FileWrites" />
     </GatherTranslatedSource>
+
+    <ItemGroup>
+      <_VSTemplatesToLocalize Include="@(VSTemplate)" Condition="'%(VSTemplate.TranslatableResources)' != ''" />
+    </ItemGroup>
+
+    <TransformTemplates Templates="@(_VSTemplatesToLocalize)"
+                        UnstructuredResources="@(UnstructuredResource)"
+                        Languages="$(XlfLanguages)"
+                        TranslatedOutputDirectory="$(XlfIntermediateOutputPath)"
+                        Condition="'@(VSTemplate)' != '' and '@(UnstructuredResource)' != ''">
+      <Output TaskParameter="TransformedTemplates" ItemName="VSTemplate" />
+    </TransformTemplates>
+    <ItemGroup>
+      <!--
+      All items of the @(_VSTemplatesToLocalize) group (which was populated from @(VSTemplate)) have been
+      re-added to the collection with the string holes removed, so @(_VSTemplatesToLocalize) can all be
+      removed from the @(VSTemplate) collection.
+      -->
+      <VSTemplate Remove="@(_VSTemplatesToLocalize)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="BatchTranslateSourceFromXlf"


### PR DESCRIPTION
Previously all translatable documents had some sort of absolute structure (e.g., XML), but for something like a Visual Studio project template, there was no support.  This PR is in two parts:

1.  Add `UnstructuredDocument.cs` to enable `.xlf` generation for all files in the `@(UnstructuredResource)` item group.  I'm open to suggestions for different formats for the unstructured document, but ultimately I settled on text holes that look like: `@@@StringId|This is the original English string@@@`.  This was picked because the marker `@@@` seems unlikely to appear in a file referenced by a `.vstemplate`; e.g., if the markers `{{{` and `}}}` were used, the closing marker could conceivably appear in the end of a C# file if a method, class, and namespace closing curly brace were all grouped together.
2.  Items in the `@(VSTemplate)` item group can be augmented with `<TranslatableResources />` metadata which indirectly adds those files to the `@(UnstructuredResource)` item group.  Next, a directory is created under `$(XlfIntermediateOutputPath)` for each language that the `.vstemplate` is being processed for.  The `.vstemplate` file is parsed and for each file reference, if a matching entry was found in the `@(UnstructuredResource)` item group, that item is copied into the directory (having already been translated/prcessed by `UnstructuredDocument.cs`); if a matching entry is _not_ found, it is assumed that the specified file has no translations and is directly copied over.  Once that has been done, the newly copied `.vstemplate` file is added to the `@(VSTemplate)` item group to be later processed by the template compiler in the VSSDK.  **There is one item to note here:** because the original files referenced by the `.vstemplate` file might have text holes (e.g., `@@@StringID:This is the original English string@@@`), an additional copy of the `.vstemplate` is copied to the `$(XlfIntermediateOutputPath)` directory and an untranslated copy of all referenced files are also copied and the original `.vstemplate` file is _removed_ from the `@(VSTemplate)` item collection.

An example of how I'd like to use these changes can be found [here](https://github.com/brettfo/visualfsharp/commit/295d0fae71cf14ddf336241096cd34073654f2c6).

@nguerrera for review.