### PR TITLE
Handle non-unique IDs in VSCT files

### DIFF
--- a/src/XliffTasks.Tests/VsctDocumentTests.cs
+++ b/src/XliffTasks.Tests/VsctDocumentTests.cs
@@ -101,5 +101,79 @@ namespace XliffTasks.Tests
 
             AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
         }
+
+        [Fact]
+        public void NonUniqueIds()
+        {
+            string source =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Commands package=""guidTestPackage"">
+    <Menus>
+      <Menu guid=""firstGuid"" id=""menuid"">
+        <Strings>
+          <MenuText>Some menu text</MenuText>
+          <ButtonText>Some button text</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu guid=""secondGuid"" id=""menuid"">
+        <Strings>
+          <MenuText>More menu text</MenuText>
+          <ButtonText>More button text</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu guid=""thirdGuid"" id=""otherMenuId"">
+        <Strings>
+          <MenuText>Even more menu text</MenuText>
+          <ButtonText>Even more button text</ButtonText>
+        </Strings>
+      </Menu>
+    </Menus>
+  </Commands>
+</CommandTable>";
+
+            var translations = new Dictionary<string, string>
+            {
+                ["firstGuid|menuid|MenuText"] = "Texte du menu",
+                ["firstGuid|menuid|ButtonText"] = "Texte du bouton",
+                ["secondGuid|menuid|MenuText"] = "Plus de texte de menu",
+                ["secondGuid|menuid|ButtonText"] = "Plus de texte de bouton",
+                ["otherMenuId|MenuText"] = "Encore plus de texte de menu",
+                ["otherMenuId|ButtonText"] = "Encore plus de texte de bouton",
+            };
+
+            string expectedTranslation =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Commands package=""guidTestPackage"">
+    <Menus>
+      <Menu guid=""firstGuid"" id=""menuid"">
+        <Strings>
+          <MenuText>Texte du menu</MenuText>
+          <ButtonText>Texte du bouton</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu guid=""secondGuid"" id=""menuid"">
+        <Strings>
+          <MenuText>Plus de texte de menu</MenuText>
+          <ButtonText>Plus de texte de bouton</ButtonText>
+        </Strings>
+      </Menu>
+      <Menu guid=""thirdGuid"" id=""otherMenuId"">
+        <Strings>
+          <MenuText>Encore plus de texte de menu</MenuText>
+          <ButtonText>Encore plus de texte de bouton</ButtonText>
+        </Strings>
+      </Menu>
+    </Menus>
+  </Commands>
+</CommandTable>";
+
+            var document = new VsctDocument();
+            var writer = new StringWriter();
+            document.Load(new StringReader(source));
+            document.Translate(translations);
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/23194

In a VSCT file elements are uniquely identified by a combination of GUID
and ID. However, currently XliffTasks only considers the ID and the tool
will crash if it encounters the same ID reused under multiple GUIDs.

To fix this we need to incorporate the GUID into the unique identifiers
we generate for every localizable resource. However, in repos that are
already using XliffTasks we don't want to re-label all existing
localizable items in VSCT files as that will cause a good bit of churn
and busy work for our translators. It will also make for unique
identifiers that are unnecessarily long in most cases.

To avoid this, this commit adds an extra pass over the document to first
find the IDs that are unique. Later when we create the
`TranslatableXmlElement` we check if the ID is unique. If not, we
prepend the GUID. This way we only include the GUID if it is really
necessary.