### PR TITLE
Don't run in design-time/LUT builds

### DIFF
--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -37,6 +37,13 @@
       there is an outer build trigger that calls inner UpdateXlf serially.
     -->
     <_IsInnerXlfBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' != ''">true</_IsInnerXlfBuild>
+  
+    <!--
+      Don't run the targets during builds for Live Unit Testing, or during design-time builds.
+      -->
+    <_IsExcludedBuild Condition="'$(BuildingForLiveUnitTesting)' == 'true'
+                                or '$(DesignTimeBuild)' == 'true'
+                                or '$(BuildingProject)' == 'false'">true</_IsExcludedBuild>
   </PropertyGroup>
 
   <!-- Updates the list of XlfSource items that drives incremental update (see above) -->
@@ -59,9 +66,7 @@
           Condition="'$(EnableXlfLocalization)' == 'true'
                      and '$(UpdateXlfOnBuild)' == 'true'
                      and '$(_IsInnerXlfBuild)' != 'true'
-                     and '$(BuildingForLiveUnitTesting)' != 'true'
-                     and '$(DesignTimeBuild)' != 'true'
-                     and '$(BuildingProject)' != 'false'"
+                     and '$(_IsExcludedBuild)' != 'true'"
           BeforeTargets="BeforeBuild"
           DependsOnTargets="UpdateXlf"
           />
@@ -133,7 +138,7 @@
   </Target>
 
   <Target Name="TranslateSourceFromXlf"
-          Condition="'$(EnableXlfLocalization)' == 'true'"
+          Condition="'$(EnableXlfLocalization)' == 'true' and '$(_IsExcludedBuild) != 'true'"
           DependsOnTargets="GatherXlf;BatchTranslateSourceFromXlf"
           BeforeTargets="VSCTCompile;PrepareResourceNames;$(PrepareResourceNamesDependsOn)"
           >

--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -56,18 +56,23 @@
   </Target>
 
   <Target Name="UpdateXlfOnBuild"
-          Condition="'$(EnableXlfLocalization)' == 'true' and '$(UpdateXlfOnBuild)' == 'true' and '$(_IsInnerXlfBuild)' != 'true'"
+          Condition="'$(EnableXlfLocalization)' == 'true'
+                     and '$(UpdateXlfOnBuild)' == 'true'
+                     and '$(_IsInnerXlfBuild)' != 'true'
+                     and '$(BuildingForLiveUnitTesting)' != 'true'
+                     and '$(DesignTimeBuild)' != 'true'
+                     and '$(BuildingProject)' != 'false'"
           BeforeTargets="BeforeBuild"
           DependsOnTargets="UpdateXlf"
           />
-  
+
   <Target Name="EnsureXlfIsUpToDate"
           Condition="'$(ErrorOnOutOfDateXlf)' == 'true'"
           DependsOnTargets="_DisallowXlfModification;_UpdateXlf"
           />
-  
+
   <Target Name="UpdateXlf"
-          DependsOnTargets="_AllowXlfModification;_UpdateXlf" 
+          DependsOnTargets="_AllowXlfModification;_UpdateXlf"
           />
 
   <Target Name="_AllowXlfModification">
@@ -116,7 +121,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GatherXlf" 
+  <Target Name="GatherXlf"
           DependsOnTargets="GetXlfSources;EnsureXlfIsUpToDate"
           >
     <GatherXlf Sources="@(XlfSource)"


### PR DESCRIPTION
Fixes #36.

Don't run `UpdateXlfOnBuild` when we're in a Live Unit Testing
background build, or in a design-time build.

1. Live Unit Testing builds set `$(BuildingForLiveUnitTesting)` to true.
2. Design-time builds for SDK-based projects set `$(DesignTimeBuild)` to true.
3. Design-time builds for csproj/msvbprj-based projects set
`$(BuildingProject)` to false.