### PR TITLE
Sort XLIFF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The `PrivateAssets` metadata is needed to prevent `dotnet pack` or `msbuild /t:p
 
 ## Using XliffTasks
 
+### Updating .xlf files
+
 Once `XliffTasks` is installed building a project will automatically build satellite assemblies from .xlf files. To _update_ .xlf files to bring them in line with the source .resx/.vsct/.xaml files you need to run the `UpdateXlf` target, like so: 
 
 ```
@@ -38,7 +40,13 @@ By default, `XliffTasks` will produce an error during build if it detects that t
 
 Many teams using `XliffTasks` default `UpdateXlfOnBuild` to true for local developer builds, but leave it off for CI builds. This way the .xlf files are automatically updated as the developer works, and the CI build will fail if the developer forgets to include the changes to the .xlf files as part of their PR. This way the .xlf files are always in sync with the source files, and can be handed off to a localization team at any time.
 
-Other workflows are possible by changing the `XliffTasks` properties.
+Other workflows are possible by changing the `XliffTasks` properties (see below)
+
+### Sorting .xlf files
+
+`XliffTasks` attempts to keep .xlf files sorted when inserting new items. This doesn't matter for the generation of satellite assemblies, but can reduce merge conflicts when localizable resources are being added in multiple branches (as opposed to always adding new items at the end, which more or less guarantees merge conflicts).
+
+Note `XliffTasks` does not force the items into a sorted order if they are not already sorted. You can do that manually by running `msbuild /t:SortXlf`.
 
 ## Properties
 

--- a/src/XliffTasks.Tests/XlfDocumentTests.cs
+++ b/src/XliffTasks.Tests/XlfDocumentTests.cs
@@ -51,20 +51,20 @@ namespace XliffTasks.Tests
 @"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
   <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
     <body>
-      <trans-unit id=""Hello"">
-        <source>Hello!</source>
-        <target state=""new"">Hello!</target>
-        <note>Greeting</note>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
       </trans-unit>
       <trans-unit id=""Goodbye"">
         <source>Goodbye!</source>
         <target state=""new"">Goodbye!</target>
         <note />
       </trans-unit>
-      <trans-unit id=""Apple"">
-        <source>Apple</source>
-        <target state=""new"">Apple</target>
-        <note>Tasty</note>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
       </trans-unit>
     </body>
   </file>
@@ -76,20 +76,20 @@ namespace XliffTasks.Tests
  @"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
   <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
     <body>
-      <trans-unit id=""Hello"">
-        <source>Hello!</source>
-        <target state=""translated"">Bonjour!</target>
-        <note>Greeting</note>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""translated"">Apple</target>
+        <note>Tasty</note>
       </trans-unit>
       <trans-unit id=""Goodbye"">
         <source>Goodbye!</source>
         <target state=""translated"">Au revoir!</target>
         <note />
       </trans-unit>
-      <trans-unit id=""Apple"">
-        <source>Apple</source>
-        <target state=""translated"">Apple</target>
-        <note>Tasty</note>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""translated"">Bonjour!</target>
+        <note>Greeting</note>
       </trans-unit>
     </body>
   </file>
@@ -117,24 +117,24 @@ namespace XliffTasks.Tests
  @"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
   <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
     <body>
-      <trans-unit id=""Goodbye"">
-        <source>Goodbye World!</source>
-        <target state=""needs-review-translation"">Au revoir!</target>
-        <note />
-      </trans-unit>
       <trans-unit id=""Apple"">
         <source>Apple</source>
         <target state=""needs-review-translation"">Apple</target>
         <note>This is referring to fruit.</note>
       </trans-unit>
-      <trans-unit id=""HelloWorld"">
-        <source>Hello World!</source>
-        <target state=""new"">Hello World!</target>
-        <note />
-      </trans-unit>
       <trans-unit id=""Banana"">
         <source>Banana</source>
         <target state=""new"">Banana</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye World!</source>
+        <target state=""needs-review-translation"">Au revoir!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""HelloWorld"">
+        <source>Hello World!</source>
+        <target state=""new"">Hello World!</target>
         <note />
       </trans-unit>
     </body>
@@ -144,6 +144,152 @@ namespace XliffTasks.Tests
              AssertEx.EqualIgnoringLineEndings(
                 xliffAfterApplyingResxModification,
                 Update(xliff: xliffAfterFirstTranslation, resx: resxAfterFirstModification));
+        }
+
+        [Fact]
+        public void NewItemThatShouldBeLastEndsUpLast()
+        {
+            // Dev has just added "Zucchini" item to RESX
+            string resx =
+@"<root>
+  <data name=""Hello"">
+    <value>Hello!</value>
+    <comment>Greeting</comment>
+  </data>
+  <data name=""Goodbye"">
+    <value>Goodbye!</value>
+  </data>
+  <data name=""Apple"">
+   <value>Apple</value>
+   <comment>Tasty</comment>
+  </data>
+  <data name=""Zucchini"">
+    <value>Zucchini</value>
+    <comment>My children won't eat it.</comment>
+  </data>
+</root>";
+
+            string xliffBeforeUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
+      </trans-unit>
+      <trans-unit id=""Zucchini"">
+        <source>Zucchini</source>
+        <target state=""new"">Zucchini</target>
+        <note>My children won't eat it.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                xliffAfterUpdate,
+                Update(xliff: xliffBeforeUpdate, resx: resx));
+
+        }
+
+        [Fact]
+        public void CheckSorting()
+        {
+            string xliff =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Gamma"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
+      </trans-unit>
+      <trans-unit id=""Beta"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Alpha"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string xliffAfterSorting =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Alpha"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Beta"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Gamma"">
+        <source>Hello!</source>
+        <target state=""new"">Hello!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                xliffAfterSorting,
+                Sort(xliff));
+        }
+
+        private static string Sort(string xliff)
+        {
+            var xliffDocument = new XlfDocument();
+            xliffDocument.Load(new StringReader(xliff));
+
+            xliffDocument.Sort();
+
+            var writer = new StringWriter();
+            xliffDocument.Save(writer);
+            return writer.ToString();
         }
 
         private static string Update(string xliff, string resx)

--- a/src/XliffTasks/EnumerableExtensions.cs
+++ b/src/XliffTasks/EnumerableExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace XliffTasks
+{
+    internal static class EnumerableExtensions
+    {
+        public static bool IsSorted<T, U>(this IEnumerable<T> source, Func<T, U> keySelector, IComparer<U> comparer)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException(nameof(keySelector));
+            }
+
+            if (comparer == null)
+            {
+                throw new ArgumentNullException(nameof(comparer));
+            }
+
+            U priorKey = default(U);
+            bool first = true;
+
+            foreach (var item in source)
+            {
+                U key = keySelector(item);
+
+                if (!first
+                    && comparer.Compare(priorKey, key) > 0)
+                {
+                    return false;
+                }
+
+                first = false;
+                priorKey = key;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/XliffTasks/Tasks/SortXlf.cs
+++ b/src/XliffTasks/Tasks/SortXlf.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using System.IO;
+using XliffTasks.Model;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class SortXlf : XlfTask
+    {
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+
+        [Required]
+        public string[] Languages { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            foreach (var item in Sources)
+            {
+                string sourceDocumentPath = item.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, item.ItemSpec);
+
+                foreach (var language in Languages)
+                {
+                    string xlfPath = GetXlfPath(sourceDocumentPath, language);
+                    XlfDocument xlfDocument;
+
+                    try
+                    {
+                        xlfDocument = LoadXlfDocument(xlfPath);
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        // If the file doesn't exist, we don't need to worry about sorting it.
+                        continue;
+                    }
+
+                    bool modified = xlfDocument.Sort();
+                    if (!modified)
+                    {
+                        continue; // no changes
+                    }
+
+                    Directory.CreateDirectory(Path.GetDirectoryName(xlfPath));
+                    xlfDocument.Save(xlfPath);
+                }
+            }
+        }
+    }
+}

--- a/src/XliffTasks/Tasks/UpdateXlf.cs
+++ b/src/XliffTasks/Tasks/UpdateXlf.cs
@@ -49,7 +49,9 @@ namespace XliffTasks.Tasks
                         throw new BuildErrorException($"'{xlfPath}' for '{sourcePath}' does not exist. {HowToUpdate}");
                     }
 
-                    if (!xlfDocument.Update(sourceDocument, sourceDocumentId))
+                    bool updated = xlfDocument.Update(sourceDocument, sourceDocumentId);
+
+                    if (!updated)
                     {
                         continue; // no changes
                     }

--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -170,18 +170,10 @@
     Sorts the trans-unit elements in the .xlf files by the value of their id attributes.
   -->
   <Target Name="SortXlf"
-          DependsOnTargets="GetXlfSources;UpdateXlfSourceList"
-          Inputs="@(XlfSource);$(_XlfSourceList)"
-          Outputs="$(_UpdateXlfLastRun)"
+          DependsOnTargets="GetXlfSources"
           >
     <SortXlf Sources="@(XlfSource)"
              Languages="$(XlfLanguages)"
              />
-
-    <Touch Files="$(_UpdateXlfLastRun)" AlwaysCreate="true" />
-
-    <ItemGroup>
-      <FileWrites Include="$(_UpdateXlfLastRun)" />
-    </ItemGroup>
   </Target>
 </Project>

--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -15,6 +15,7 @@
   <UsingTask TaskName="TransformTemplates" AssemblyFile="$(XliffTasksAssembly)" />
   <UsingTask TaskName="TranslateSource" AssemblyFile="$(XliffTasksAssembly)" />
   <UsingTask TaskName="UpdateXlf" AssemblyFile="$(XliffTasksAssembly)" />
+  <UsingTask TaskName="SortXlf" AssemblyFile="$(XliffTasksAssembly)" />
 
   <!--
     Note that .xlf files are source files, not build outputs. We therefore cannot use their modification time
@@ -165,4 +166,22 @@
     <TranslateSource XlfFile="@(Xlf)" />
   </Target>
 
+  <!--
+    Sorts the trans-unit elements in the .xlf files by the value of their id attributes.
+  -->
+  <Target Name="SortXlf"
+          DependsOnTargets="GetXlfSources;UpdateXlfSourceList"
+          Inputs="@(XlfSource);$(_XlfSourceList)"
+          Outputs="$(_UpdateXlfLastRun)"
+          >
+    <SortXlf Sources="@(XlfSource)"
+             Languages="$(XlfLanguages)"
+             />
+
+    <Touch Files="$(_UpdateXlfLastRun)" AlwaysCreate="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_UpdateXlfLastRun)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes #15.

Support sorting the `trans-unit` items in .xlf files. There are two parts to this:

1. There is a new target, `SortXlf`, with a corresponding task. When invoked it will sort all the `trans-unit` elements in the .xlf files by their `id` attributes. This is meant to be run manually, ala `msbuild /t:SortXlf`, rather than run automatically as part of the build.
2. When inserting a new `trans-unit` element we perform a linear scan for the first existing `trans-unit` that sorts _after_ the new one, and place the new one immediately before it. Thus, even if the list of `trans-unit` elements as a whole isn't sorted we still avoid the merge conflicts caused by always adding items at the end.