### PR TITLE
Add a target to ensure all resources are translated

### DIFF
--- a/src/XliffTasks.Tests/XlfDocumentTests.cs
+++ b/src/XliffTasks.Tests/XlfDocumentTests.cs
@@ -280,6 +280,64 @@ namespace XliffTasks.Tests
                 Sort(xliff));
         }
 
+        [Fact]
+        public void UntranslatedResourceCount_Zero()
+        {
+            string xliff =
+ @"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""translated"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""translated"">Au revoir!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""translated"">Bonjour!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            Assert.Equal(expected: 0, actual: UntranslatedResourceCount(xliff));
+        }
+
+        [Fact]
+        public void UntranslatedResourceCount_Two()
+        {
+            string xliff =
+ @"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""translated"">Apple</target>
+        <note>Tasty</note>
+      </trans-unit>
+      <trans-unit id=""Goodbye"">
+        <source>Goodbye!</source>
+        <target state=""new"">Goodbye!</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Hello"">
+        <source>Hello!</source>
+        <target state=""needs-review-translation"">Hallo!</target>
+        <note>Greeting</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            Assert.Equal(expected: 2, actual: UntranslatedResourceCount(xliff));
+        }
+
         private static string Sort(string xliff)
         {
             var xliffDocument = new XlfDocument();
@@ -312,6 +370,14 @@ namespace XliffTasks.Tests
             var writer = new StringWriter();
             xliffDocument.Save(writer);
             return writer.ToString();
+        }
+
+        private static int UntranslatedResourceCount(string xliff)
+        {
+            var xliffDocument = new XlfDocument();
+            xliffDocument.Load(new StringReader(xliff));
+
+            return xliffDocument.GetUntranslatedResourceCount();
         }
     }
 }

--- a/src/XliffTasks/Model/XlfDocument.cs
+++ b/src/XliffTasks/Model/XlfDocument.cs
@@ -257,5 +257,18 @@ namespace XliffTasks.Model
 
             return dictionary;
         }
+
+        public int GetUntranslatedResourceCount()
+        {
+            XNamespace ns = _document.Root.Name.Namespace;
+
+            int untranslatedResourceCount =
+                (_document.Descendants(ns + "trans-unit")
+                 .Select(tu => tu.Element(ns + "target"))
+                 .Where(target => target.Attribute("state").Value != "translated"))
+                .Count();
+
+            return untranslatedResourceCount;
+        }
     }
 }

--- a/src/XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
+++ b/src/XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using System.IO;
+using XliffTasks.Model;
+
+namespace XliffTasks.Tasks
+{
+    public sealed class EnsureAllResourcesTranslated : XlfTask
+    {
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+
+        [Required]
+        public string[] Languages { get; set; }
+
+        protected override void ExecuteCore()
+        {
+            foreach (var item in Sources)
+            {
+                string sourceDocumentPath = item.GetMetadataOrDefault(MetadataKey.SourceDocumentPath, item.ItemSpec);
+
+                foreach (var language in Languages)
+                {
+                    string xlfPath = GetXlfPath(sourceDocumentPath, language);
+                    XlfDocument xlfDocument;
+
+                    try
+                    {
+                        xlfDocument = LoadXlfDocument(xlfPath);
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        // If the file doesn't exist, we don't need to worry about it having
+                        // untranslated resources.
+                        continue;
+                    }
+
+                    int untranslatedResourceCount = xlfDocument.GetUntranslatedResourceCount();
+                    if (untranslatedResourceCount > 0)
+                    {
+                        Log.LogError($"Xliff file '{xlfPath}' has {untranslatedResourceCount} untranslated resources.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -16,6 +16,7 @@
   <UsingTask TaskName="TranslateSource" AssemblyFile="$(XliffTasksAssembly)" />
   <UsingTask TaskName="UpdateXlf" AssemblyFile="$(XliffTasksAssembly)" />
   <UsingTask TaskName="SortXlf" AssemblyFile="$(XliffTasksAssembly)" />
+  <UsingTask TaskName="EnsureAllResourcesTranslated" AssemblyFile="$(XliffTasksAssembly)" />
 
   <!--
     Note that .xlf files are source files, not build outputs. We therefore cannot use their modification time
@@ -61,14 +62,14 @@
           BeforeTargets="BeforeBuild"
           DependsOnTargets="UpdateXlf"
           />
-  
+
   <Target Name="EnsureXlfIsUpToDate"
           Condition="'$(ErrorOnOutOfDateXlf)' == 'true'"
           DependsOnTargets="_DisallowXlfModification;_UpdateXlf"
           />
-  
+
   <Target Name="UpdateXlf"
-          DependsOnTargets="_AllowXlfModification;_UpdateXlf" 
+          DependsOnTargets="_AllowXlfModification;_UpdateXlf"
           />
 
   <Target Name="_AllowXlfModification">
@@ -117,7 +118,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GatherXlf" 
+  <Target Name="GatherXlf"
           DependsOnTargets="GetXlfSources;EnsureXlfIsUpToDate"
           >
     <GatherXlf Sources="@(XlfSource)"
@@ -175,5 +176,13 @@
     <SortXlf Sources="@(XlfSource)"
              Languages="$(XlfLanguages)"
              />
+  </Target>
+
+  <Target Name="EnsureAllResourcesTranslated"
+          DependsOnTargets="GetXlfSources"
+          >
+    <EnsureAllResourcesTranslated Sources="@(XlfSource)"
+                                  Languages="$(XlfLanguages)"
+                                  />
   </Target>
 </Project>


### PR DESCRIPTION
Add an `EnsureAllResourcesTranslated` task and target that verifies all `trans-unit` items are in a `translated` state. If not, MSBuild errors are logged, failing the build.

Fixes #53.