### PR TITLE
Add sorting and checking to outer build

### DIFF
--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -178,6 +178,9 @@
              />
   </Target>
 
+  <!--
+    Checks that all trans-unit elements in the .xlf files have an up-to-date translation.
+  -->
   <Target Name="EnsureAllResourcesTranslated"
           DependsOnTargets="GetXlfSources"
           >

--- a/src/XliffTasks/buildCrossTargeting/XliffTasks.targets
+++ b/src/XliffTasks/buildCrossTargeting/XliffTasks.targets
@@ -28,4 +28,42 @@
              />
   </Target>
 
+  <!--
+    Sorts the trans-unit elements in the .xlf files by the value of their id attributes.
+    Runs a sort per target framework as resource files may be conditioned on the framework.
+  -->
+  <Target Name="SortXlf">
+    <ItemGroup>
+      <_XlfTargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+
+    <!--
+      These inner builds cannot be parallelized as they would race to 
+      update the same inner xlf files.
+    -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="SortXlf"
+             Properties="TargetFramework=%(_XlfTargetFramework.Identity)"
+             />
+  </Target>
+
+  <!--
+    Checks that all trans-unit elements in the .xlf files have an up-to-date translation.
+    Runs a sort per target framework as resource files may be conditioned on the framework.
+  -->
+  <Target Name="EnsureAllResourcesTranslated">
+    <ItemGroup>
+      <_XlfTargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+    
+    <!--
+      These inner builds can be run in parallel as they don't modify any files.
+    -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="EnsureAllResourcesTranslated"
+             Properties="TargetFramework=%(_XlfTargetFramework.Identity)"
+             BuildInParallel="true"
+             />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Right now the `SortXlf` and `EnsureAllResourcesTranslated` targets are available to the _inner_ build. To make these targets available in projects targeting multiple frameworks we need to expose them to the _outer_ build--otherwise you will see MSBuild errors about the target not being found. The outer build implementation simply kicks off a new build per target framework; these "inner" builds will end up using the existing targets.