### PR TITLE
Log better error messages when .xlf file is invalid

### DIFF
--- a/src/XliffTasks/Tasks/BuildErrorException.cs
+++ b/src/XliffTasks/Tasks/BuildErrorException.cs
@@ -7,7 +7,22 @@ namespace XliffTasks.Tasks
 {
     internal sealed class BuildErrorException : Exception
     {
+        /// <summary>
+        /// Well-known key for associating a file path with this
+        /// <see cref="BuildErrorException"/>.
+        /// 
+        /// When a file path is added to the <see cref="Exception.Data"/> dictionary
+        /// using this value as the key, the file will be associated with the error in
+        /// the build logs.
+        /// </summary>
+        public const string RelatedFile = "RelatedFile";
+
         public BuildErrorException(string message) : base(message)
+        {
+        }
+
+        public BuildErrorException(string message, Exception innerException)
+            : base(message, innerException)
         {
         }
     }

--- a/src/XliffTasks/Tasks/BuildErrorException.cs
+++ b/src/XliffTasks/Tasks/BuildErrorException.cs
@@ -8,22 +8,13 @@ namespace XliffTasks.Tasks
     internal sealed class BuildErrorException : Exception
     {
         /// <summary>
-        /// Well-known key for associating a file path with this
-        /// <see cref="BuildErrorException"/>.
-        /// 
-        /// When a file path is added to the <see cref="Exception.Data"/> dictionary
-        /// using this value as the key, the file will be associated with the error in
-        /// the build logs.
+        /// The file associated with this <see cref="BuildErrorException"/>.
         /// </summary>
-        public const string RelatedFile = "RelatedFile";
+        public string RelatedFile { get; set;}
 
         public BuildErrorException(string message) : base(message)
         {
         }
 
-        public BuildErrorException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
     }
 }

--- a/src/XliffTasks/Tasks/UpdateXlf.cs
+++ b/src/XliffTasks/Tasks/UpdateXlf.cs
@@ -43,10 +43,17 @@ namespace XliffTasks.Tasks
                     {
                         xlfDocument = LoadXlfDocument(xlfPath, language, createIfNonExistent: AllowModification);
                     }
-                    catch (FileNotFoundException ex) when (ex.FileName == xlfPath)
+                    catch (FileNotFoundException fileNotFoundEx) when (fileNotFoundEx.FileName == xlfPath)
                     {
                         Release.Assert(!AllowModification);
                         throw new BuildErrorException($"'{xlfPath}' for '{sourcePath}' does not exist. {HowToUpdate}");
+                    }
+                    catch (System.Xml.XmlException xmlEx)
+                    {
+                        throw new BuildErrorException("Unable to load file.", xmlEx)
+                        {
+                            Data = { { BuildErrorException.RelatedFile, xlfPath } }
+                        };
                     }
 
                     bool updated = xlfDocument.Update(sourceDocument, sourceDocumentId);

--- a/src/XliffTasks/Tasks/UpdateXlf.cs
+++ b/src/XliffTasks/Tasks/UpdateXlf.cs
@@ -50,9 +50,9 @@ namespace XliffTasks.Tasks
                     }
                     catch (System.Xml.XmlException xmlEx)
                     {
-                        throw new BuildErrorException("Unable to load file.", xmlEx)
+                        throw new BuildErrorException($"Unable to load file: {xmlEx.Message}")
                         {
-                            Data = { { BuildErrorException.RelatedFile, xlfPath } }
+                            RelatedFile = xlfPath
                         };
                     }
 

--- a/src/XliffTasks/Tasks/XlfTask.cs
+++ b/src/XliffTasks/Tasks/XlfTask.cs
@@ -20,7 +20,7 @@ namespace XliffTasks.Tasks
             }
             catch (BuildErrorException ex)
             {
-                Log.LogErrorFromException(ex, showStackTrace: false, showDetail: true, file: (string)ex.Data[BuildErrorException.RelatedFile]);
+                Log.LogErrorFromException(ex, showStackTrace: false, showDetail: false, file: ex.RelatedFile);
             }
 
             return !Log.HasLoggedErrors;
@@ -53,7 +53,7 @@ namespace XliffTasks.Tasks
             {
                 throw new BuildErrorException($"Unknown source file format '{format}'.")
                 {
-                    Data = { { BuildErrorException.RelatedFile, path } }
+                    RelatedFile = path
                 };
             }
 

--- a/src/XliffTasks/Tasks/XlfTask.cs
+++ b/src/XliffTasks/Tasks/XlfTask.cs
@@ -20,7 +20,7 @@ namespace XliffTasks.Tasks
             }
             catch (BuildErrorException ex)
             {
-                Log.LogErrorFromException(ex, showStackTrace: false);
+                Log.LogErrorFromException(ex, showStackTrace: false, showDetail: true, file: (string)ex.Data[BuildErrorException.RelatedFile]);
             }
 
             return !Log.HasLoggedErrors;
@@ -51,7 +51,10 @@ namespace XliffTasks.Tasks
             }
             else
             {
-                throw new BuildErrorException($"Unknown source file format '{format}'.");
+                throw new BuildErrorException($"Unknown source file format '{format}'.")
+                {
+                    Data = { { BuildErrorException.RelatedFile, path } }
+                };
             }
 
             document.Load(path);


### PR DESCRIPTION
I ran into a situation where an XLIFF file had become corrupted and the `UpdateXlf` target failed when `XDocument.Load` threw a `System.Xml.XmlException`. This resulted in MSBuild dumping out the exception message and stack trace for the failure, but not the file path as it wasn't part of the exception. Identifying the problematic file required digging through all of the .xlf files associated with the project until I found the bad one.

This change catches the `XmlException` and wraps it in a
`BuildErrorException` that includes the file path, and ensures the file
path is printed as part of the log message. The file path has been added
to a few other places where we were already throwing
`BuildErrorExceptions` as well.