### PR TITLE
Shorten error messages associated with missing resources

### DIFF
--- a/src/XliffTasks/EnumerableExtensions.cs
+++ b/src/XliffTasks/EnumerableExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
+++ b/src/XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
@@ -46,8 +46,17 @@ namespace XliffTasks.Tasks
 
                 if (untranslatedResourceSet.Count > 0)
                 {
-                    string untranslatedResourceNames = string.Join(Environment.NewLine, untranslatedResourceSet);
-                    Log.LogError($"File '{sourceDocumentPath}' has {untranslatedResourceSet.Count} untranslated resource(s):{Environment.NewLine}{untranslatedResourceNames}");
+                    string untranslatedResourceNames = string.Join(", ", untranslatedResourceSet);
+                    Log.LogError(
+                        subcategory: null,
+                        errorCode: null,
+                        helpKeyword: null,
+                        file: sourceDocumentPath,
+                        lineNumber: 0,
+                        columnNumber: 0,
+                        endLineNumber: 0,
+                        endColumnNumber: 0,
+                        message: $"Found {untranslatedResourceSet.Count} untranslated resource(s): {untranslatedResourceNames}");
                 }
             }
         }

--- a/src/XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
+++ b/src/XliffTasks/Tasks/EnsureAllResourcesTranslated.cs
@@ -47,16 +47,7 @@ namespace XliffTasks.Tasks
                 if (untranslatedResourceSet.Count > 0)
                 {
                     string untranslatedResourceNames = string.Join(", ", untranslatedResourceSet);
-                    Log.LogError(
-                        subcategory: null,
-                        errorCode: null,
-                        helpKeyword: null,
-                        file: sourceDocumentPath,
-                        lineNumber: 0,
-                        columnNumber: 0,
-                        endLineNumber: 0,
-                        endColumnNumber: 0,
-                        message: $"Found {untranslatedResourceSet.Count} untranslated resource(s): {untranslatedResourceNames}");
+                    Log.LogErrorInFile(sourceDocumentPath, $"Found {untranslatedResourceSet.Count} untranslated resource(s): {untranslatedResourceNames}");
                 }
             }
         }

--- a/src/XliffTasks/Tasks/TaskLoggingHelperExtensions.cs
+++ b/src/XliffTasks/Tasks/TaskLoggingHelperExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Utilities;
+
+namespace XliffTasks.Tasks
+{
+    internal static class TaskLoggingHelperExtensions
+    {
+        /// <summary>
+        /// Helper method to log MSBuild errors associated with a particular file.
+        /// </summary>
+        public static void LogErrorInFile(this TaskLoggingHelper log, string file, string message)
+        {
+            log.LogError(
+                subcategory: null,
+                errorCode: null,
+                helpKeyword: null,
+                file: file,
+                lineNumber: 0,
+                columnNumber: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message: message);
+        }
+    }
+}


### PR DESCRIPTION
Currently, when running the `EnsureAllResourcesTranslated` target/task, each untranslated resource ID will be printed out on a separate line. The "blame" also goes to the .targets file containing the target, rather than the original .resx or .vsct. The path to that file appears in the error message.

This change re-works the error reporting to blame the original file, and joins the untranslated IDs into a single line. This should greatly reduce the output spew in the common case. The resulting error now looks like this:

```
"c:\repos\XliffTasksTest\XliffTasksTest.sln" (EnsureAllREsourcesTranslated target) (1) ->
"c:\repos\XliffTasksTest\XliffTasksTest\XliffTasksTest.csproj" (EnsureAllREsourcesTranslated target) (2) ->
(EnsureAllResourcesTranslated target) ->
  MyResources.resx : error : Found 2 untranslated resource(s): Alpha, Beta [c:\repos\XliffTasksTest\XliffTasksTest\XliffTasksTest.csproj]
```