### PR TITLE
Reset translations when the number of replacements changes

### DIFF
--- a/src/XliffTasks.Tests/ResxDocumentTests.cs
+++ b/src/XliffTasks.Tests/ResxDocumentTests.cs
@@ -84,68 +84,6 @@ namespace XliffTasks.Tests
             AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
         }
 
-        [Fact]
-        public void GetReplacementCount_NoPlaceHolders()
-        {
-            var text = "Alpha";
-
-            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
-
-            Assert.Equal(expected: 0, actual: maxPlaceHolderCount);
-        }
-
-        [Fact]
-        public void GetReplacementCount_OneSimplePlaceHolder()
-        {
-            var text = "{0}";
-            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
-
-            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
-        }
-
-        [Fact]
-        public void GetReplacementCount_PlaceHolderWithAlignment()
-        {
-            var text = "{0,-3}";
-            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
-
-            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
-        }
-
-        [Fact]
-        public void GetReplacementCount_PlaceHolderWithFormatString()
-        {
-            var text = "{0:N}";
-            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
-
-            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
-        }
-
-        [Fact]
-        public void GetReplacementCount_WithAlignmentAndFormatString()
-        {
-            var text = "{0,-10:G1}";
-            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
-
-            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
-        }
-
-        [Fact]
-        public void GetReplacementCount_MultiplePlaceHolders()
-        {
-            var text = "{0} {1}";
-            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
-
-            Assert.Equal(expected: 2, actual: maxPlaceHolderCount);
-        }
-
-        [Fact]
-        public void GetReplacementCount_MultipleIdenticalPlaceHolders()
-        {
-            var text = "{2} {2}";
-            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
-
-            Assert.Equal(expected: 3, actual: maxPlaceHolderCount);
-        }
+        
     }
 }

--- a/src/XliffTasks.Tests/ResxDocumentTests.cs
+++ b/src/XliffTasks.Tests/ResxDocumentTests.cs
@@ -84,5 +84,68 @@ namespace XliffTasks.Tests
             AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
         }
 
+        [Fact]
+        public void GetReplacementCount_NoPlaceHolders()
+        {
+            var text = "Alpha";
+
+            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
+
+            Assert.Equal(expected: 0, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_OneSimplePlaceHolder()
+        {
+            var text = "{0}";
+            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
+
+            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_PlaceHolderWithAlignment()
+        {
+            var text = "{0,-3}";
+            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
+
+            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_PlaceHolderWithFormatString()
+        {
+            var text = "{0:N}";
+            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
+
+            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_WithAlignmentAndFormatString()
+        {
+            var text = "{0,-10:G1}";
+            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
+
+            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_MultiplePlaceHolders()
+        {
+            var text = "{0} {1}";
+            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
+
+            Assert.Equal(expected: 2, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_MultipleIdenticalPlaceHolders()
+        {
+            var text = "{2} {2}";
+            var maxPlaceHolderCount = ResxDocument.GetReplacementCount(text);
+
+            Assert.Equal(expected: 3, actual: maxPlaceHolderCount);
+        }
     }
 }

--- a/src/XliffTasks.Tests/StringExtensionsTests.cs
+++ b/src/XliffTasks.Tests/StringExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace XliffTasks.Tests
+{
+    public class StringExtensionsTests
+    {
+        [Fact]
+        public void GetReplacementCount_NoPlaceHolders()
+        {
+            var text = "Alpha";
+            var maxPlaceHolderCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 0, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_OneSimplePlaceHolder()
+        {
+            var text = "{0}";
+            var maxPlaceHolderCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_PlaceHolderWithAlignment()
+        {
+            var text = "{0,-3}";
+            var maxPlaceHolderCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_PlaceHolderWithFormatString()
+        {
+            var text = "{0:N}";
+            var maxPlaceHolderCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_WithAlignmentAndFormatString()
+        {
+            var text = "{0,-10:G1}";
+            var maxPlaceHolderCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_MultiplePlaceHolders()
+        {
+            var text = "{0} {1}";
+            var maxPlaceHolderCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 2, actual: maxPlaceHolderCount);
+        }
+
+        [Fact]
+        public void GetReplacementCount_MultipleIdenticalPlaceHolders()
+        {
+            var text = "{2} {2}";
+            var maxPlaceHolderCount = text.GetReplacementCount();
+
+            Assert.Equal(expected: 3, actual: maxPlaceHolderCount);
+        }
+    }
+}

--- a/src/XliffTasks.Tests/StringExtensionsTests.cs
+++ b/src/XliffTasks.Tests/StringExtensionsTests.cs
@@ -8,66 +8,66 @@ namespace XliffTasks.Tests
     public class StringExtensionsTests
     {
         [Fact]
-        public void GetReplacementCount_NoPlaceHolders()
+        public void GetReplacementCount_NoPlaceholders()
         {
             var text = "Alpha";
-            var maxPlaceHolderCount = text.GetReplacementCount();
+            var replacementCount = text.GetReplacementCount();
 
-            Assert.Equal(expected: 0, actual: maxPlaceHolderCount);
+            Assert.Equal(expected: 0, actual: replacementCount);
         }
 
         [Fact]
-        public void GetReplacementCount_OneSimplePlaceHolder()
+        public void GetReplacementCount_OneSimplePlaceholder()
         {
             var text = "{0}";
-            var maxPlaceHolderCount = text.GetReplacementCount();
+            var replacementCount = text.GetReplacementCount();
 
-            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+            Assert.Equal(expected: 1, actual: replacementCount);
         }
 
         [Fact]
-        public void GetReplacementCount_PlaceHolderWithAlignment()
+        public void GetReplacementCount_PlaceholderWithAlignment()
         {
             var text = "{0,-3}";
-            var maxPlaceHolderCount = text.GetReplacementCount();
+            var replacementCount = text.GetReplacementCount();
 
-            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+            Assert.Equal(expected: 1, actual: replacementCount);
         }
 
         [Fact]
-        public void GetReplacementCount_PlaceHolderWithFormatString()
+        public void GetReplacementCount_PlaceholderWithFormatString()
         {
             var text = "{0:N}";
-            var maxPlaceHolderCount = text.GetReplacementCount();
+            var replacementCount = text.GetReplacementCount();
 
-            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+            Assert.Equal(expected: 1, actual: replacementCount);
         }
 
         [Fact]
         public void GetReplacementCount_WithAlignmentAndFormatString()
         {
             var text = "{0,-10:G1}";
-            var maxPlaceHolderCount = text.GetReplacementCount();
+            var replacementCount = text.GetReplacementCount();
 
-            Assert.Equal(expected: 1, actual: maxPlaceHolderCount);
+            Assert.Equal(expected: 1, actual: replacementCount);
         }
 
         [Fact]
-        public void GetReplacementCount_MultiplePlaceHolders()
+        public void GetReplacementCount_MultiplePlaceholders()
         {
             var text = "{0} {1}";
-            var maxPlaceHolderCount = text.GetReplacementCount();
+            var replacementCount = text.GetReplacementCount();
 
-            Assert.Equal(expected: 2, actual: maxPlaceHolderCount);
+            Assert.Equal(expected: 2, actual: replacementCount);
         }
 
         [Fact]
-        public void GetReplacementCount_MultipleIdenticalPlaceHolders()
+        public void GetReplacementCount_MultipleIdenticalPlaceholders()
         {
             var text = "{2} {2}";
-            var maxPlaceHolderCount = text.GetReplacementCount();
+            var replacementCount = text.GetReplacementCount();
 
-            Assert.Equal(expected: 3, actual: maxPlaceHolderCount);
+            Assert.Equal(expected: 3, actual: replacementCount);
         }
     }
 }

--- a/src/XliffTasks.Tests/XlfDocumentTests.cs
+++ b/src/XliffTasks.Tests/XlfDocumentTests.cs
@@ -344,6 +344,77 @@ namespace XliffTasks.Tests
             Assert.DoesNotContain("Apple", untranslatedResources, StringComparer.Ordinal);
         }
 
+        [Fact]
+        public void ResetTranslationOnMismatchedPlaceholders()
+        {
+            // Dev has just added additional placeholders to items Alpha and Beta.
+            // Gamma already had a placeholder and is not being changed.
+
+            string resx =
+@"<root>
+  <data name=""Alpha"">
+    <value>Alpha {0}</value>
+  </data>
+  <data name=""Beta"">
+    <value>Beta {0} {1}</value>
+  </data>
+  <data name=""Gamma"">
+    <value>Gamma {0}</value>
+  </data>
+</root>";
+
+            string xliffBeforeUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Alpha"">
+        <source>Alpha</source>
+        <target state=""translated"">Translated Alpha</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Beta"">
+        <source>Beta {0}</source>
+        <target state=""translated"">Translated Beta {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Gamma"">
+        <source>Gamma {0}</source>
+        <target state=""translated"">Translated Gamma {0}</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Alpha"">
+        <source>Alpha {0}</source>
+        <target state=""new"">Alpha {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Beta"">
+        <source>Beta {0} {1}</source>
+        <target state=""new"">Beta {0} {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Gamma"">
+        <source>Gamma {0}</source>
+        <target state=""translated"">Translated Gamma {0}</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                xliffAfterUpdate,
+                Update(xliff: xliffBeforeUpdate, resx: resx));
+
+        }
+
         private static string Sort(string xliff)
         {
             var xliffDocument = new XlfDocument();

--- a/src/XliffTasks/Model/ResxDocument.cs
+++ b/src/XliffTasks/Model/ResxDocument.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace XliffTasks.Model
@@ -71,6 +73,47 @@ namespace XliffTasks.Model
                     valueNodeOfFileRef.Value = string.Join(";", splitRelativePathAndSerializedType);
                 }
             }
+        }
+
+        /// <summary>
+        /// Attempts to match formatting placeholders as documented at
+        /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting.
+        /// Explanation:
+        /// \{
+        ///    A placeholder starts with an open curly brace. Since curly braces are used in
+        ///    regex syntax we escape it to be clear that we mean a literal {.
+        ///
+        /// (\d+)
+        ///    The "index" component; one or more decimal digits. This is captured in a group
+        ///    to facilitate extracting the numeric value.
+        ///
+        /// (\,\-?\d+)?
+        ///    The optional "alignment" component. This is a comma, followed by an optional
+        ///    minus sign, followed by one or more decimal digits.
+        ///
+        /// (\:[^\}]+)?
+        ///    The optional "format string" componet. This is a colon, followed by one or more
+        ///    characters that aren't close curly braces.
+        ///
+        /// \}
+        ///    The close curly brace indicates the end of the placeholder.
+        /// </summary>
+        private static Regex s_placeHolderRegex = new Regex(@"\{(\d+)(\,\-?\d+)?(\:[^\}]+)?\}", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Returns the number of replacement strings needed to properly format the given text.
+        /// </summary>
+        public static int GetReplacementCount(string text)
+        {
+            int placeHolderCount = 0;
+
+            foreach (Match placeHolder in s_placeHolderRegex.Matches(text))
+            {
+                var index = int.Parse(placeHolder.Groups[1].Value);
+                placeHolderCount = Math.Max(placeHolderCount, index + 1);
+            }
+
+            return placeHolderCount;
         }
     }
 }

--- a/src/XliffTasks/Model/ResxDocument.cs
+++ b/src/XliffTasks/Model/ResxDocument.cs
@@ -74,46 +74,5 @@ namespace XliffTasks.Model
                 }
             }
         }
-
-        /// <summary>
-        /// Attempts to match formatting placeholders as documented at
-        /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting.
-        /// Explanation:
-        /// \{
-        ///    A placeholder starts with an open curly brace. Since curly braces are used in
-        ///    regex syntax we escape it to be clear that we mean a literal {.
-        ///
-        /// (\d+)
-        ///    The "index" component; one or more decimal digits. This is captured in a group
-        ///    to facilitate extracting the numeric value.
-        ///
-        /// (\,\-?\d+)?
-        ///    The optional "alignment" component. This is a comma, followed by an optional
-        ///    minus sign, followed by one or more decimal digits.
-        ///
-        /// (\:[^\}]+)?
-        ///    The optional "format string" componet. This is a colon, followed by one or more
-        ///    characters that aren't close curly braces.
-        ///
-        /// \}
-        ///    The close curly brace indicates the end of the placeholder.
-        /// </summary>
-        private static Regex s_placeHolderRegex = new Regex(@"\{(\d+)(\,\-?\d+)?(\:[^\}]+)?\}", RegexOptions.Compiled);
-
-        /// <summary>
-        /// Returns the number of replacement strings needed to properly format the given text.
-        /// </summary>
-        public static int GetReplacementCount(string text)
-        {
-            int placeHolderCount = 0;
-
-            foreach (Match placeHolder in s_placeHolderRegex.Matches(text))
-            {
-                var index = int.Parse(placeHolder.Groups[1].Value);
-                placeHolderCount = Math.Max(placeHolderCount, index + 1);
-            }
-
-            return placeHolderCount;
-        }
     }
 }

--- a/src/XliffTasks/Model/XlfDocument.cs
+++ b/src/XliffTasks/Model/XlfDocument.cs
@@ -155,26 +155,23 @@ namespace XliffTasks.Model
                     changed = true;
                 }
 
-                if (sourceDocument is ResxDocument)
+                // If the source and target require different numbers of formatting items then reset
+                // the target string completely. This avoids problems when the source has been updated
+                // to remove formatting items--when formatting the target string we won't have as many
+                // replacement items as it calls for, leading to an exception.
+                // And if the source string is updated to use _more_ items then formatting with the
+                // target string is likely to produce misleading (or outright meaningless) text. In
+                // either case we lose nothing by just reverting the string until it can be localized
+                // again.
+                var sourceReplacementCount = sourceElement.Value.GetReplacementCount();
+                var targetReplacementCount = targetElement.Value.GetReplacementCount();
+
+                if (targetReplacementCount != sourceReplacementCount)
                 {
-                    // If the source and target require different numbers of formatting items then reset
-                    // the target string completely. This avoids problems when the source has been updated
-                    // to remove formatting items--when formatting the target string we won't have as many
-                    // replacement items as it calls for, leading to an exception.
-                    // And if the source string is updated to use _more_ items then formatting with the
-                    // target string is likely to produce misleading (or outright meaningless) text. In
-                    // either case we lose nothing by just reverting the string until it can be localized
-                    // again.
-                    var sourceReplacementCount = ResxDocument.GetReplacementCount(sourceElement.Value);
-                    var targetReplacementCount = ResxDocument.GetReplacementCount(targetElement.Value);
+                    targetElement.Value = sourceNode.Source;
+                    stateAttribute.Value = "new";
 
-                    if (targetReplacementCount != sourceReplacementCount)
-                    {
-                        targetElement.Value = sourceNode.Source;
-                        stateAttribute.Value = "new";
-
-                        changed = true;
-                    }
+                    changed = true;
                 }
 
                 // signal to loop below that this node is not new

--- a/src/XliffTasks/Model/XlfDocument.cs
+++ b/src/XliffTasks/Model/XlfDocument.cs
@@ -163,6 +163,8 @@ namespace XliffTasks.Model
                 // target string is likely to produce misleading (or outright meaningless) text. In
                 // either case we lose nothing by just reverting the string until it can be localized
                 // again.
+                // Note we don't limit this check to when the source has changed in the original
+                // document because we also want to catch errors introduced during translation.
                 var sourceReplacementCount = sourceElement.Value.GetReplacementCount();
                 var targetReplacementCount = targetElement.Value.GetReplacementCount();
 

--- a/src/XliffTasks/Model/XlfDocument.cs
+++ b/src/XliffTasks/Model/XlfDocument.cs
@@ -172,6 +172,8 @@ namespace XliffTasks.Model
                     {
                         targetElement.Value = sourceNode.Source;
                         stateAttribute.Value = "new";
+
+                        changed = true;
                     }
                 }
 

--- a/src/XliffTasks/Model/XlfDocument.cs
+++ b/src/XliffTasks/Model/XlfDocument.cs
@@ -155,6 +155,26 @@ namespace XliffTasks.Model
                     changed = true;
                 }
 
+                if (sourceDocument is ResxDocument)
+                {
+                    // If the source and target require different numbers of formatting items then reset
+                    // the target string completely. This avoids problems when the source has been updated
+                    // to remove formatting items--when formatting the target string we won't have as many
+                    // replacement items as it calls for, leading to an exception.
+                    // And if the source string is updated to use _more_ items then formatting with the
+                    // target string is likely to produce misleading (or outright meaningless) text. In
+                    // either case we lose nothing by just reverting the string until it can be localized
+                    // again.
+                    var sourceReplacementCount = ResxDocument.GetReplacementCount(sourceElement.Value);
+                    var targetReplacementCount = ResxDocument.GetReplacementCount(targetElement.Value);
+
+                    if (targetReplacementCount != sourceReplacementCount)
+                    {
+                        targetElement.Value = sourceNode.Source;
+                        stateAttribute.Value = "new";
+                    }
+                }
+
                 // signal to loop below that this node is not new
                 nodesById.Remove(id);
             }

--- a/src/XliffTasks/StringExtensions.cs
+++ b/src/XliffTasks/StringExtensions.cs
@@ -27,28 +27,28 @@ namespace XliffTasks
         ///    minus sign, followed by one or more decimal digits.
         ///
         /// (\:[^\}]+)?
-        ///    The optional "format string" componet. This is a colon, followed by one or more
+        ///    The optional "format string" component. This is a colon, followed by one or more
         ///    characters that aren't close curly braces.
         ///
         /// \}
         ///    The close curly brace indicates the end of the placeholder.
         /// </summary>
-        private static Regex s_placeHolderRegex = new Regex(@"\{(\d+)(\,\-?\d+)?(\:[^\}]+)?\}", RegexOptions.Compiled);
+        private static Regex s_placeholderRegex = new Regex(@"\{(\d+)(\,\-?\d+)?(\:[^\}]+)?\}", RegexOptions.Compiled);
 
         /// <summary>
         /// Returns the number of replacement strings needed to properly format the given text.
         /// </summary>
         public static int GetReplacementCount(this string text)
         {
-            int placeHolderCount = 0;
+            int replacementCount = 0;
 
-            foreach (Match placeHolder in s_placeHolderRegex.Matches(text))
+            foreach (Match placeholder in s_placeholderRegex.Matches(text))
             {
-                var index = int.Parse(placeHolder.Groups[1].Value);
-                placeHolderCount = Math.Max(placeHolderCount, index + 1);
+                var index = int.Parse(placeholder.Groups[1].Value);
+                replacementCount = Math.Max(replacementCount, index + 1);
             }
 
-            return placeHolderCount;
+            return replacementCount;
         }
     }
 }

--- a/src/XliffTasks/StringExtensions.cs
+++ b/src/XliffTasks/StringExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace XliffTasks
+{
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Attempts to match formatting placeholders as documented at
+        /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting.
+        ///
+        /// Explanation:
+        ///
+        /// \{
+        ///    A placeholder starts with an open curly brace. Since curly braces are used in
+        ///    regex syntax we escape it to be clear that we mean a literal {.
+        ///
+        /// (\d+)
+        ///    The "index" component; one or more decimal digits. This is captured in a group
+        ///    to facilitate extracting the numeric value.
+        ///
+        /// (\,\-?\d+)?
+        ///    The optional "alignment" component. This is a comma, followed by an optional
+        ///    minus sign, followed by one or more decimal digits.
+        ///
+        /// (\:[^\}]+)?
+        ///    The optional "format string" componet. This is a colon, followed by one or more
+        ///    characters that aren't close curly braces.
+        ///
+        /// \}
+        ///    The close curly brace indicates the end of the placeholder.
+        /// </summary>
+        private static Regex s_placeHolderRegex = new Regex(@"\{(\d+)(\,\-?\d+)?(\:[^\}]+)?\}", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Returns the number of replacement strings needed to properly format the given text.
+        /// </summary>
+        public static int GetReplacementCount(this string text)
+        {
+            int placeHolderCount = 0;
+
+            foreach (Match placeHolder in s_placeHolderRegex.Matches(text))
+            {
+                var index = int.Parse(placeHolder.Groups[1].Value);
+                placeHolderCount = Math.Max(placeHolderCount, index + 1);
+            }
+
+            return placeHolderCount;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #52.

Reset translations when the number of replacements changes in the source text. If the number of replacement _increases_ then until the target string is updated to a new translation formatting it will likely produce misleading or just plain meaningless text.

If the number of replacements _decreases_ then the target string will refer to replacement items that no longer exist, leading to exceptions when formatting the target.

To avoid these problem just reset the target string to the source value when we detect that they require different numbers of replacement items. The tricky bit here is correctly identifying the placeholders so we can check their indices--here I've gone with a regex and attempted to document how it works.