### PR TITLE
Handle missing elements and attributes

### DIFF
--- a/src/XliffTasks.Tests/XElementExtensionsTests.cs
+++ b/src/XliffTasks.Tests/XElementExtensionsTests.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using XliffTasks.Model;
+using Xunit;
+
+namespace XliffTasks.Tests
+{
+    public class XElementExtensionsTests
+    {
+        private static XNamespace XliffNS = "urn:oasis:names:tc:xliff:document:1.2";
+        private static XNamespace XsiNS = "http://www.w3.org/2001/XMLSchema-instance";
+        private static XName Xliff = XliffNS + "xliff";
+        private static XName File = XliffNS + "file";
+        private static XName Body = XliffNS + "body";
+        private static XName Group = XliffNS + "group";
+        private static XName TransUnit = XliffNS + "trans-unit";
+        private static XName Source = XliffNS + "source";
+        private static XName Target = XliffNS + "target";
+        private static XName Note = XliffNS + "note";
+
+        [Fact]
+        public void GetTargetValueOrDefault_ReturnsTargetWhenTargetIsPresent()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Source, "source text"),
+                    new XElement(Target, "target text"));
+
+            string targetValue = transUnitElement.GetTargetValueOrDefault();
+
+            Assert.Equal(expected: "target text", actual: targetValue);
+        }
+
+        [Fact]
+        public void GetTargetValueOrDefault_ReturnsEmptyStringWhenTargetIsEmpty()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Source, "source text"),
+                    new XElement(Target, string.Empty));
+
+            string targetValue = transUnitElement.GetTargetValueOrDefault();
+
+            Assert.Equal(expected: string.Empty, actual: targetValue);
+        }
+
+        [Fact]
+        public void GetTargetValueOrDefault_ReturnsSourceWhenTargetIsMissing()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Source, "source text"));
+
+            string targetValue = transUnitElement.GetTargetValueOrDefault();
+
+            Assert.Equal(expected: "source text", actual: targetValue);
+        }
+
+        [Fact]
+        public void SetTargetValue_SetsValueIfTargetIsPresent()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Source, "source text"),
+                    new XElement(Target, "original target text"),
+                    new XElement(Note));
+
+            transUnitElement.SetTargetValue("new target text");
+
+            Assert.Equal(expected: "new target text", actual: transUnitElement.Element(Target).Value);
+        }
+
+        [Fact]
+        public void SetTargetValue_TargetIsCreatedIfNotPresent()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Source, "source text"),
+                    new XElement(Note));
+
+            transUnitElement.SetTargetValue("new target text");
+
+            Assert.Equal(expected: "new target text", actual: transUnitElement.Element(Target).Value);
+            Assert.Equal(expected: transUnitElement.Element(Source), actual: transUnitElement.Element(Target).PreviousNode);
+        }
+
+        [Fact]
+        public void GetTargetState_ReturnsStateWhenStateIsPresent()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Target,
+                        new XAttribute("state", "original state value")));
+
+            string stateValue = transUnitElement.GetTargetStateOrDefault();
+
+            Assert.Equal(expected: "original state value", actual: stateValue);
+        }
+
+        [Fact]
+        public void GetTargetState_ReturnsDefaultWhenTargetIsPresentButStateIsNot()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Target));
+
+            string stateValue = transUnitElement.GetTargetStateOrDefault();
+
+            Assert.Equal(expected: "new", actual: stateValue);
+        }
+
+        [Fact]
+        public void GetTargetState_ReturnsDefaultWhenTargetIsNotPresent()
+        {
+            XElement transUnitElement = new XElement(TransUnit);
+
+            string stateValue = transUnitElement.GetTargetStateOrDefault();
+
+            Assert.Equal(expected: "new", actual: stateValue);
+        }
+
+        [Fact]
+        public void SetTargetState_SetsStateWhenAlreadyPresent()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Source, "soruce text"),
+                    new XElement(Target,
+                        new XAttribute("state", "new"),
+                        "target text"));
+
+            transUnitElement.SetTargetState("translated");
+
+            Assert.Equal(expected: "translated", actual: transUnitElement.Element(Target).Attribute("state").Value);
+        }
+
+        [Fact]
+        public void SetTargetState_AddsStateAttributeIfNotPresent()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Source, "soruce text"),
+                    new XElement(Target, "target text"));
+
+            transUnitElement.SetTargetState("translated");
+
+            Assert.Equal(expected: "translated", actual: transUnitElement.Element(Target).Attribute("state").Value);
+        }
+
+        [Fact]
+        public void SetTargetState_AddsTargetElementIfNotPresent()
+        {
+            XElement transUnitElement =
+                new XElement(TransUnit,
+                    new XElement(Source, "soruce text"));
+
+            transUnitElement.SetTargetState("translated");
+
+            Assert.Equal(expected: "translated", actual: transUnitElement.Element(Target).Attribute("state").Value);
+        }
+    }
+}

--- a/src/XliffTasks.Tests/XElementExtensionsTests.cs
+++ b/src/XliffTasks.Tests/XElementExtensionsTests.cs
@@ -4,22 +4,12 @@
 using System.Xml.Linq;
 using XliffTasks.Model;
 using Xunit;
+using static XliffTasks.Model.XlfNames;
 
 namespace XliffTasks.Tests
 {
     public class XElementExtensionsTests
     {
-        private static XNamespace XliffNS = "urn:oasis:names:tc:xliff:document:1.2";
-        private static XNamespace XsiNS = "http://www.w3.org/2001/XMLSchema-instance";
-        private static XName Xliff = XliffNS + "xliff";
-        private static XName File = XliffNS + "file";
-        private static XName Body = XliffNS + "body";
-        private static XName Group = XliffNS + "group";
-        private static XName TransUnit = XliffNS + "trans-unit";
-        private static XName Source = XliffNS + "source";
-        private static XName Target = XliffNS + "target";
-        private static XName Note = XliffNS + "note";
-
         [Fact]
         public void GetTargetValueOrDefault_ReturnsTargetWhenTargetIsPresent()
         {

--- a/src/XliffTasks.Tests/XElementExtensionsTests.cs
+++ b/src/XliffTasks.Tests/XElementExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace XliffTasks.Tests
                     new XElement(Source, "source text"),
                     new XElement(Target, "target text"));
 
-            string targetValue = transUnitElement.GetTargetValueOrDefault();
+            string targetValue = transUnitElement.GetTargetValue();
 
             Assert.Equal(expected: "target text", actual: targetValue);
         }
@@ -31,7 +31,7 @@ namespace XliffTasks.Tests
                     new XElement(Source, "source text"),
                     new XElement(Target, string.Empty));
 
-            string targetValue = transUnitElement.GetTargetValueOrDefault();
+            string targetValue = transUnitElement.GetTargetValue();
 
             Assert.Equal(expected: string.Empty, actual: targetValue);
         }
@@ -43,7 +43,7 @@ namespace XliffTasks.Tests
                 new XElement(TransUnit,
                     new XElement(Source, "source text"));
 
-            string targetValue = transUnitElement.GetTargetValueOrDefault();
+            string targetValue = transUnitElement.GetTargetValue();
 
             Assert.Equal(expected: "source text", actual: targetValue);
         }
@@ -84,7 +84,7 @@ namespace XliffTasks.Tests
                     new XElement(Target,
                         new XAttribute("state", "original state value")));
 
-            string stateValue = transUnitElement.GetTargetStateOrDefault();
+            string stateValue = transUnitElement.GetTargetState();
 
             Assert.Equal(expected: "original state value", actual: stateValue);
         }
@@ -96,7 +96,7 @@ namespace XliffTasks.Tests
                 new XElement(TransUnit,
                     new XElement(Target));
 
-            string stateValue = transUnitElement.GetTargetStateOrDefault();
+            string stateValue = transUnitElement.GetTargetState();
 
             Assert.Equal(expected: "new", actual: stateValue);
         }
@@ -106,7 +106,7 @@ namespace XliffTasks.Tests
         {
             XElement transUnitElement = new XElement(TransUnit);
 
-            string stateValue = transUnitElement.GetTargetStateOrDefault();
+            string stateValue = transUnitElement.GetTargetState();
 
             Assert.Equal(expected: "new", actual: stateValue);
         }

--- a/src/XliffTasks.Tests/XlfDocumentTests.cs
+++ b/src/XliffTasks.Tests/XlfDocumentTests.cs
@@ -72,7 +72,7 @@ namespace XliffTasks.Tests
     </body>
   </file>
 </xliff>";
-             AssertEx.EqualIgnoringLineEndings(xliff, Update(xliff: "", resx: resx));
+            AssertEx.EqualIgnoringLineEndings(xliff, Update(xliff: "", resx: resx));
 
             // loc team translates
             string xliffAfterFirstTranslation =
@@ -144,9 +144,154 @@ namespace XliffTasks.Tests
   </file>
 </xliff>";
 
-             AssertEx.EqualIgnoringLineEndings(
-                xliffAfterApplyingResxModification,
-                Update(xliff: xliffAfterFirstTranslation, resx: resxAfterFirstModification));
+            AssertEx.EqualIgnoringLineEndings(
+               xliffAfterApplyingResxModification,
+               Update(xliff: xliffAfterFirstTranslation, resx: resxAfterFirstModification));
+        }
+
+        [Fact]
+        public void UpdateBehavesCorrectlyWhenTargetIsMissing()
+        {
+            string initialXliff =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Banana"">
+        <source>Banana</source>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string resxWithModifications =
+@"<root>
+  <data name=""Apple"">
+   <value>Better apples</value>
+  </data>
+  <data name=""Banana"">
+    <value>Banana</value>
+  </data>
+</root>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Better apples</source>
+        <target state=""new"">Better apples</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Banana"">
+        <source>Banana</source>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                expected: xliffAfterUpdate,
+                actual: Update(initialXliff, resxWithModifications));
+        }
+
+        [Fact]
+        public void UpdateBehavesCorrectlyWhenNoteIsMissing()
+        {
+            string initialXliff =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+      </trans-unit>
+      <trans-unit id=""Banana"">
+        <source>Banana</source>
+        <target state=""new"">Banana</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string resxWithModifications =
+@"<root>
+  <data name=""Apple"">
+   <value>Apple</value>
+   <comment>Make sure they're green apples.</comment>
+  </data>
+  <data name=""Banana"">
+    <value>Banana</value>
+  </data>
+</root>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target state=""new"">Apple</target>
+        <note>Make sure they're green apples.</note>
+      </trans-unit>
+      <trans-unit id=""Banana"">
+        <source>Banana</source>
+        <target state=""new"">Banana</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                expected: xliffAfterUpdate,
+                actual: Update(initialXliff, resxWithModifications));
+        }
+
+        [Fact]
+        public void UpdateBehavesCorrectlyWhenTargetStateIsMissing()
+        {
+            string initialXliff =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Apple</source>
+        <target>Apple</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            string resxWithModifications =
+@"<root>
+  <data name=""Apple"">
+   <value>Better apples</value>
+  </data>
+</root>";
+
+            string xliffAfterUpdate =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.resx"">
+    <body>
+      <trans-unit id=""Apple"">
+        <source>Better apples</source>
+        <target state=""new"">Better apples</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
+
+            AssertEx.EqualIgnoringLineEndings(
+                expected: xliffAfterUpdate,
+                actual: Update(initialXliff, resxWithModifications));
         }
 
         [Fact]

--- a/src/XliffTasks/Model/XElementExtensions.cs
+++ b/src/XliffTasks/Model/XElementExtensions.cs
@@ -1,23 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Xml.Linq;
+using static XliffTasks.Model.XlfNames;
 
 namespace XliffTasks.Model
 {
     internal static class XElementExtensions
     {
-        private static XNamespace XliffNS = "urn:oasis:names:tc:xliff:document:1.2";
-        private static XNamespace XsiNS = "http://www.w3.org/2001/XMLSchema-instance";
-        private static XName Xliff = XliffNS + "xliff";
-        private static XName File = XliffNS + "file";
-        private static XName Body = XliffNS + "body";
-        private static XName Group = XliffNS + "group";
-        private static XName TransUnit = XliffNS + "trans-unit";
-        private static XName Source = XliffNS + "source";
-        private static XName Target = XliffNS + "target";
-        private static XName Note = XliffNS + "note";
-
         public static string GetTargetValueOrDefault(this XElement transUnitElement) => 
             transUnitElement.Element(Target)?.Value
             ?? transUnitElement.Element(Source).Value;

--- a/src/XliffTasks/Model/XElementExtensions.cs
+++ b/src/XliffTasks/Model/XElementExtensions.cs
@@ -8,10 +8,24 @@ namespace XliffTasks.Model
 {
     internal static class XElementExtensions
     {
+        /// <summary>
+        /// Returns the effective target value of a <code>trans-unit</code> element in an XLIFF file.
+        /// If the <code>trans-unit</code> has no <code>target</code> child, returns the value of the <code>source</code>
+        /// child.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>target</code> element if it exists; otherwise the value of the
+        /// <code>source</code> element.</returns>
         public static string GetTargetValue(this XElement transUnitElement) => 
             transUnitElement.Element(Target)?.Value
             ?? transUnitElement.Element(Source).Value;
 
+        /// <summary>
+        /// Sets the target value of a <code>trans-unit</code> element in an XLIFF file.
+        /// Creates the <code>target</code> element and <code>state</code> attribute as necessary.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <param name="value">The new target value.</param>
         public static void SetTargetValue(this XElement transUnitElement, string value)
         {
             XElement targetElement = transUnitElement.Element(Target);
@@ -29,10 +43,23 @@ namespace XliffTasks.Model
             }
         }
 
+        /// <summary>
+        /// Returns the effective target translation of a <code>trans-unit</code> element in an XLIFF file.
+        /// If the <code>trans-unit</code> has no <code>target</code> element or <code>state</code> attribute,
+        /// returns a default value ("new").
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>state</code> attribute if it exists, otherwise "new".</returns>
         public static string GetTargetState(this XElement transUnitElement) =>
             transUnitElement.Element(Target)?.Attribute("state")?.Value
             ?? "new";
 
+        /// <summary>
+        /// Sets the target translation state of a <code>trans-unit</code> element in an XLIFF file.
+        /// Creates the <code>target</code> element and <code>state</code> attribute as necessary.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <param name="value">The new state value.</param>
         public static void SetTargetState(this XElement transUnitElement, string value)
         {
             XElement targetElement = transUnitElement.Element(Target);
@@ -55,15 +82,37 @@ namespace XliffTasks.Model
             }
         }
 
+        /// <summary>
+        /// Gets the <code>source</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>source</code> element.</returns>
         public static string GetSourceValue(this XElement transUnitElement) =>
             transUnitElement.Element(Source).Value;
 
+        /// <summary>
+        /// Sets the <code>source</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <param name="value">The new <code>source</code> value.</param>
         public static void SetSourceValue(this XElement transUnitElement, string value) =>
             transUnitElement.Element(Source).Value = value;
 
+        /// <summary>
+        /// Gets the <code>note</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>note</code> element, or <code>null</code> if it does not exist.</returns>
         public static string GetNoteValue(this XElement transUnitElement) =>
             transUnitElement.Element(Note)?.Value;
 
+        /// <summary>
+        /// Sets the <code>note</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// Creates the <code>note</code> element as needed, and places it in the correct location
+        /// relative to the <code>source</code> and <code>target</code> elements.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <param name="value">The new <code>note</code> value.</param>
         public static void SetNoteValue(this XElement transUnitElement, string value)
         {
             XElement noteElement = transUnitElement.Element(Note);
@@ -78,6 +127,11 @@ namespace XliffTasks.Model
             noteElement.SelfCloseIfPossible();
         }
 
+        /// <summary>
+        /// Gets the <code>id</code> value of a <code>trans-unit</code> element in an XLIFF file.
+        /// </summary>
+        /// <param name="transUnitElement">An <see cref="XElement"/> representing the <code>trans-unit</code>.</param>
+        /// <returns>The value of the <code>id</code> attribute.</returns>
         public static string GetId(this XElement transUnitElement) =>
             transUnitElement.Attribute("id").Value;
     }

--- a/src/XliffTasks/Model/XElementExtensions.cs
+++ b/src/XliffTasks/Model/XElementExtensions.cs
@@ -8,7 +8,7 @@ namespace XliffTasks.Model
 {
     internal static class XElementExtensions
     {
-        public static string GetTargetValueOrDefault(this XElement transUnitElement) => 
+        public static string GetTargetValue(this XElement transUnitElement) => 
             transUnitElement.Element(Target)?.Value
             ?? transUnitElement.Element(Source).Value;
 
@@ -29,7 +29,7 @@ namespace XliffTasks.Model
             }
         }
 
-        public static string GetTargetStateOrDefault(this XElement transUnitElement) =>
+        public static string GetTargetState(this XElement transUnitElement) =>
             transUnitElement.Element(Target)?.Attribute("state")?.Value
             ?? "new";
 

--- a/src/XliffTasks/Model/XElementExtensions.cs
+++ b/src/XliffTasks/Model/XElementExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+
+namespace XliffTasks.Model
+{
+    internal static class XElementExtensions
+    {
+        private static XNamespace XliffNS = "urn:oasis:names:tc:xliff:document:1.2";
+        private static XNamespace XsiNS = "http://www.w3.org/2001/XMLSchema-instance";
+        private static XName Xliff = XliffNS + "xliff";
+        private static XName File = XliffNS + "file";
+        private static XName Body = XliffNS + "body";
+        private static XName Group = XliffNS + "group";
+        private static XName TransUnit = XliffNS + "trans-unit";
+        private static XName Source = XliffNS + "source";
+        private static XName Target = XliffNS + "target";
+        private static XName Note = XliffNS + "note";
+
+        public static string GetTargetValueOrDefault(this XElement transUnitElement) => 
+            transUnitElement.Element(Target)?.Value
+            ?? transUnitElement.Element(Source).Value;
+
+        public static void SetTargetValue(this XElement transUnitElement, string value)
+        {
+            XElement targetElement = transUnitElement.Element(Target);
+            if (targetElement == null)
+            {
+                XElement sourceElement = transUnitElement.Element(Source);
+                targetElement = new XElement(Target);
+                sourceElement.AddAfterSelf(targetElement);
+            }
+
+            targetElement.Value = value;
+        }
+
+        public static string GetTargetStateOrDefault(this XElement transUnitElement) =>
+            transUnitElement.Element(Target)?.Attribute("state")?.Value
+            ?? "new";
+
+        public static void SetTargetState(this XElement transUnitElement, string value)
+        {
+            XElement targetElement = transUnitElement.Element(Target);
+            if (targetElement == null)
+            {
+                XElement sourceElement = transUnitElement.Element(Source);
+                targetElement = new XElement(Target);
+                sourceElement.AddAfterSelf(targetElement);
+            }
+
+            XAttribute stateAttribute = targetElement.Attribute("state");
+            if (stateAttribute == null)
+            {
+                stateAttribute = new XAttribute("state", value);
+                targetElement.Add(stateAttribute);
+            }
+            else
+            {
+                stateAttribute.Value = value;
+            }
+        }
+    }
+}

--- a/src/XliffTasks/Model/XElementExtensions.cs
+++ b/src/XliffTasks/Model/XElementExtensions.cs
@@ -18,11 +18,15 @@ namespace XliffTasks.Model
             if (targetElement == null)
             {
                 XElement sourceElement = transUnitElement.Element(Source);
-                targetElement = new XElement(Target);
+                targetElement = new XElement(Target, new XAttribute("state", "new"));
                 sourceElement.AddAfterSelf(targetElement);
             }
 
             targetElement.Value = value;
+            if (targetElement.Attribute("state") == null)
+            {
+                targetElement.Add(new XAttribute("state", "new"));
+            }
         }
 
         public static string GetTargetStateOrDefault(this XElement transUnitElement) =>
@@ -50,5 +54,31 @@ namespace XliffTasks.Model
                 stateAttribute.Value = value;
             }
         }
+
+        public static string GetSourceValue(this XElement transUnitElement) =>
+            transUnitElement.Element(Source).Value;
+
+        public static void SetSourceValue(this XElement transUnitElement, string value) =>
+            transUnitElement.Element(Source).Value = value;
+
+        public static string GetNoteValue(this XElement transUnitElement) =>
+            transUnitElement.Element(Note)?.Value;
+
+        public static void SetNoteValue(this XElement transUnitElement, string value)
+        {
+            XElement noteElement = transUnitElement.Element(Note);
+            if (noteElement == null)
+            {
+                XElement priorElement = transUnitElement.Element(Target) ?? transUnitElement.Element(Source);
+                noteElement = new XElement(Note);
+                priorElement.AddAfterSelf(noteElement);
+            }
+
+            noteElement.Value = value;
+            noteElement.SelfCloseIfPossible();
+        }
+
+        public static string GetId(this XElement transUnitElement) =>
+            transUnitElement.Attribute("id").Value;
     }
 }

--- a/src/XliffTasks/Model/XlfDocument.cs
+++ b/src/XliffTasks/Model/XlfDocument.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using XliffTasks.Tasks;
+using static XliffTasks.Model.XlfNames;
 
 namespace XliffTasks.Model
 {
@@ -23,16 +23,7 @@ namespace XliffTasks.Model
     {
         private static XmlSchemaSet s_schemaSet;
         
-        private static XNamespace XliffNS = "urn:oasis:names:tc:xliff:document:1.2";
         private static XNamespace XsiNS = "http://www.w3.org/2001/XMLSchema-instance";
-        private static XName Xliff = XliffNS + "xliff";
-        private static XName File = XliffNS + "file";
-        private static XName Body = XliffNS + "body";
-        private static XName Group = XliffNS + "group";
-        private static XName TransUnit = XliffNS + "trans-unit";
-        private static XName Source = XliffNS + "source";
-        private static XName Target = XliffNS + "target";
-        private static XName Note = XliffNS + "note";
 
         private XDocument _document;
 
@@ -44,7 +35,7 @@ namespace XliffTasks.Model
         /// <summary>
         /// Loads (or reloads) the document content from the given reader.
         /// </summary>
-        public override void Load(TextReader reader)
+        public override void Load(System.IO.TextReader reader)
         {
             _document = XDocument.Load(reader);
         }
@@ -71,7 +62,7 @@ namespace XliffTasks.Model
         /// <summary>
         /// Saves the document's content (with translations applied if <see cref="Translate" /> was called) to the given file path.
         /// </summary>
-        public override void Save(TextWriter writer)
+        public override void Save(System.IO.TextWriter writer)
         {
             EnsureContent();
             _document.SaveCustom(writer);
@@ -117,7 +108,6 @@ namespace XliffTasks.Model
             foreach (XElement unitElement in bodyElement.Descendants(TransUnit).ToList())
             {
                 XElement sourceElement = unitElement.Element(Source);
-                
                 XElement targetElement = unitElement.Element(Target);
                 XElement noteElement = unitElement.Element(Note);
                 XAttribute idAttribute = unitElement.Attribute("id");
@@ -326,9 +316,9 @@ namespace XliffTasks.Model
         {
             if (s_schemaSet == null)
             {
-                Stream xmlSchemaResourceStream = typeof(XlfDocument).Assembly.GetManifestResourceStream("XliffTasks.Model.xml.xsd");
+                System.IO.Stream xmlSchemaResourceStream = typeof(XlfDocument).Assembly.GetManifestResourceStream("XliffTasks.Model.xml.xsd");
                 XmlReader xmlSchemaReader = XmlReader.Create(xmlSchemaResourceStream);
-                Stream xliffSchemaResourceStream = typeof(XlfDocument).Assembly.GetManifestResourceStream("XliffTasks.Model.xliff-core-1.2-transitional.xsd");
+                System.IO.Stream xliffSchemaResourceStream = typeof(XlfDocument).Assembly.GetManifestResourceStream("XliffTasks.Model.xliff-core-1.2-transitional.xsd");
                 XmlReader xliffSchemaReader = XmlReader.Create(xliffSchemaResourceStream);
 
                 var schemas = new XmlSchemaSet();

--- a/src/XliffTasks/Model/XlfDocument.cs
+++ b/src/XliffTasks/Model/XlfDocument.cs
@@ -108,7 +108,7 @@ namespace XliffTasks.Model
             foreach (XElement unitElement in bodyElement.Descendants(TransUnit).ToList())
             {
                 string id = unitElement.GetId();
-                string state = unitElement.GetTargetStateOrDefault();
+                string state = unitElement.GetTargetState();
                 string source = unitElement.GetSourceValue();
                 string note = unitElement.GetNoteValue();
 
@@ -160,7 +160,7 @@ namespace XliffTasks.Model
                 // Note we don't limit this check to when the source has changed in the original
                 // document because we also want to catch errors introduced during translation.
                 var sourceReplacementCount = unitElement.GetSourceValue().GetReplacementCount();
-                var targetReplacementCount = unitElement.GetTargetValueOrDefault().GetReplacementCount();
+                var targetReplacementCount = unitElement.GetTargetValue().GetReplacementCount();
 
                 if (targetReplacementCount != sourceReplacementCount)
                 {
@@ -265,7 +265,7 @@ namespace XliffTasks.Model
             foreach (var element in _document.Descendants(TransUnit))
             {
                 string id = element.GetId();
-                string target = element.GetTargetValueOrDefault();
+                string target = element.GetTargetValue();
 
                 dictionary.Add(id, target);
             }
@@ -281,7 +281,7 @@ namespace XliffTasks.Model
                 (_document.Descendants(TransUnit)
                  .Where(tu =>
                  {
-                     return tu.GetTargetStateOrDefault() != "translated";
+                     return tu.GetTargetState() != "translated";
                  })
                  .Select(tu => tu.GetId()));
 

--- a/src/XliffTasks/Model/XlfNames.cs
+++ b/src/XliffTasks/Model/XlfNames.cs
@@ -7,14 +7,14 @@ namespace XliffTasks.Model
 {
     internal static class XlfNames
     {
-        public static XNamespace XliffNS = "urn:oasis:names:tc:xliff:document:1.2";
-        public static XName Xliff = XliffNS + "xliff";
-        public static XName File = XliffNS + "file";
-        public static XName Body = XliffNS + "body";
-        public static XName Group = XliffNS + "group";
-        public static XName TransUnit = XliffNS + "trans-unit";
-        public static XName Source = XliffNS + "source";
-        public static XName Target = XliffNS + "target";
-        public static XName Note = XliffNS + "note";
+        public static readonly XNamespace XliffNS = "urn:oasis:names:tc:xliff:document:1.2";
+        public static readonly XName Xliff = XliffNS + "xliff";
+        public static readonly XName File = XliffNS + "file";
+        public static readonly XName Body = XliffNS + "body";
+        public static readonly XName Group = XliffNS + "group";
+        public static readonly XName TransUnit = XliffNS + "trans-unit";
+        public static readonly XName Source = XliffNS + "source";
+        public static readonly XName Target = XliffNS + "target";
+        public static readonly XName Note = XliffNS + "note";
     }
 }

--- a/src/XliffTasks/Model/XlfNames.cs
+++ b/src/XliffTasks/Model/XlfNames.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+
+namespace XliffTasks.Model
+{
+    internal static class XlfNames
+    {
+        public static XNamespace XliffNS = "urn:oasis:names:tc:xliff:document:1.2";
+        public static XName Xliff = XliffNS + "xliff";
+        public static XName File = XliffNS + "file";
+        public static XName Body = XliffNS + "body";
+        public static XName Group = XliffNS + "group";
+        public static XName TransUnit = XliffNS + "trans-unit";
+        public static XName Source = XliffNS + "source";
+        public static XName Target = XliffNS + "target";
+        public static XName Note = XliffNS + "note";
+    }
+}


### PR DESCRIPTION
Recent localization PRs into various repos using XliffTasks sometimes deleted the `target` child of a `trans-unit` element when no translation was available. This led to `NullReferenceException`s in XliffTasks when we attempted to retrieve the translations.

It turns out that, according to the XLIFF spec, the `target` child is optional, and even where it is present its `state` attribute is also optional. These changes bring our handling of `target` and `state` in line with the spec by defining and adopting a number of helper methods for getting and setting the various children of `trans-unit` elements. In particular, these children return us the value of `source` element when the `target` is unavailable, and report the `state` as "new" when it is not defined.

Similarly, when setting the `target` or `state` values the helpers create the relevant elements if they do not already exist.