### PR TITLE
Don't pull schema files from the internet

### DIFF
--- a/src/XliffTasks/Model/xliff-core-1.2-transitional.xsd
+++ b/src/XliffTasks/Model/xliff-core-1.2-transitional.xsd
@@ -29,7 +29,7 @@ Jan-10-2006
 -->
 <xsd:schema xmlns:xlf="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:oasis:names:tc:xliff:document:1.2" xml:lang="en">
 	<!-- Import for xml:lang and xml:space -->
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
 	<!-- Attributes Lists -->
 	<xsd:simpleType name="XTend">
 		<xsd:restriction base="xsd:string">


### PR DESCRIPTION
The xliff-core-1.2-transitional.xsd schema file imports the xml.xsd
schema file, and we include a local copy of the xml.xsd for use in
validation. However, the XLIFF schema file imports xml.xsd from a
URL--and it appears that this sometimes causes us to try and download
xml.xsd from the internet. It also seems to mean that our `XmlSchemaSet`
ends up with duplicate copies, leading it to fail with errors to the
effect that "xml:lang has already been declared".

Since we've got our own copy of xml.xsd already, here we update our copy
of xliff-core-1.2-transitional.xsd to remove the URL and avoid any
issues with reading it from online, or duplicate definitions.