### PR TITLE
Remove MSBuildAllProjects property

### DIFF
--- a/src/XliffTasks/build/XliffTasks.props
+++ b/src/XliffTasks/build/XliffTasks.props
@@ -4,8 +4,6 @@
 <Project>
 
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-
     <!-- 
       Set this to to true to update .xlf files with corresponding .resx/.vcst/.xaml on every build.
 

--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -4,7 +4,6 @@
 <Project>
 
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.0\</XliffTasksDirectory>
     <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net46\</XliffTasksDirectory>
     <XliffTasksAssembly>$(XliffTasksDirectory)XliffTasks.dll</XliffTasksAssembly>


### PR DESCRIPTION
Starting in Visual Studio 2019, this property is no longer required to be set - and only increases the working set and allocations in a large solution. While VS 2017 and lower still respects it, it is not needed as these come from NuGet packages and they are immutable and therefore do not need to be inputs into csc.