### PR TITLE
Do not null reference when Bitmaps have no href

### DIFF
--- a/src/XliffTasks.Tests/VsctDocumentTests.cs
+++ b/src/XliffTasks.Tests/VsctDocumentTests.cs
@@ -103,6 +103,26 @@ namespace XliffTasks.Tests
         }
 
         [Fact]
+        public void DoesNotNullReferenceWhenNoHRef()
+        {
+            string source =
+@"<CommandTable xmlns=""http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <Bitmaps>
+    <Bitmap guid=""guidImages"" usedList=""bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows"" />
+  </Bitmaps>
+</CommandTable>";
+
+            var document = new VsctDocument();
+            var writer = new StringWriter();
+            document.Load(new StringReader(source));
+            document.RewriteRelativePathsToAbsolute(
+                        Path.Combine(Directory.GetCurrentDirectory(), "Resources.resx"));
+            document.Save(writer);
+
+            AssertEx.EqualIgnoringLineEndings(source, writer.ToString());
+        }
+
+        [Fact]
         public void NonUniqueIds()
         {
             string source =

--- a/src/XliffTasks/Model/VsctDocument.cs
+++ b/src/XliffTasks/Model/VsctDocument.cs
@@ -78,11 +78,16 @@ namespace XliffTasks.Model
         {
             foreach (var imageTag in Document.Descendants(Document.Root.Name.Namespace + "Bitmap"))
             {
-                string resourceRelativePath = imageTag.Attribute("href").Value.Replace('\\', Path.DirectorySeparatorChar);
+                var hrefAttribute = imageTag.Attribute("href");
 
-                var absolutePath = Path.Combine(Path.GetDirectoryName(sourceFullPath), resourceRelativePath);
+                if (hrefAttribute != null)
+                {
+                    string resourceRelativePath = hrefAttribute.Value.Replace('\\', Path.DirectorySeparatorChar);
 
-                imageTag.Attribute("href").Value = absolutePath;
+                    var absolutePath = Path.Combine(Path.GetDirectoryName(sourceFullPath), resourceRelativePath);
+
+                    imageTag.Attribute("href").Value = absolutePath;
+                }
             }
         }
     }


### PR DESCRIPTION
Not all bitmaps have hrefs, some refer to built-in resources.