### PR TITLE
Disable using pipeline stages publishing

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
   - name: _BuildConfig 
     value: Release
   - name: _PublishUsingPipelines
-    value: true
+    value: false
   - name: _DotNetArtifactsCategory
     value: .NETCore
 
@@ -65,8 +65,9 @@ jobs:
           value: /p:SignType=$(_SignType)
       strategy:
         matrix:
-          Debug:
-            _BuildConfig: Debug
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            Debug:
+              _BuildConfig: Debug
           Release:
             _BuildConfig: Release
       steps:


### PR DESCRIPTION
FYI @nguerrera @tmeschter 

This repo isn't on stages yet, but was trying to publish using pipelines which meant that the artifacts weren't actually getting published to the blob feed.  

Disabling pipeline publishing.  I would have enabled stages for this build, but it looks like the repo needs to take an Arcade update and I didn't have cycles to go down that trail.  @riarenas , can you add this repo to the list of repos you're tracking for moving to stages?

Validation build is in progress - https://dnceng.visualstudio.com/internal/_build/results?buildId=287096&view=logs&j=0fd5a3c8-8713-5552-3719-1afb6ae86d33