### PR TITLE
Enable stages for xliff tasks

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -14,96 +14,99 @@ variables:
   - name: _DotNetArtifactsCategory
     value: .NETCore
 
-jobs:
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableMicrobuild: true
-    enablePublishBuildArtifacts: true
-    enablePublishTestResults: false
-    enablePublishBuildAssets: true
-    enablePublishUsingPipelines: $(_PublishUsingPipelines)
-    enableTelemetry: true
-    helixRepo: dotnet/standard
-    jobs:
-    - job: Windows_NT
-      pool: 
-        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.windows.10.amd64.vs2017.open
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2017
-      variables:
-      # Enable signing for internal, non-PR builds
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        - group: DotNet-Blob-Feed
-        - group: DotNet-Symbol-Server-Pats
-        - name: _SignType
-          value: Real
-        - name: _DotNetPublishToBlobFeed
-          value: true
-        - name: _BuildArgs
-          value: /p:SignType=$(_SignType)
-            /p:DotNetSignType=$(_SignType)
-            /p:MicroBuild_SigningEnabled=true 
-            /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-            /p:TeamName=$(_TeamName)
-            /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-            /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-            /p:DotNetPublishToBlobFeed=true
-            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-            /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        - name: _OfficialBuildIdArgs
-      # else
-      - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _SignType
-          value: Test
-        - name: _BuildArgs
-          value: /p:SignType=$(_SignType)
-      strategy:
-        matrix:
-          Debug:
-            _BuildConfig: Debug
-          Release:
-            _BuildConfig: Release
-      steps:
-      - checkout: self
-        clean: true
-      - script: eng\common\cibuild.cmd
-          -configuration $(_BuildConfig) 
-          -prepareMachine
-          -warnaserror:0
-          $(_BuildArgs)
-        displayName: Windows Build / Publish
-
-    # Linux leg (only runs in CI)
-    - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      - job: Linux
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: false
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: $(_PublishUsingPipelines)
+      enableTelemetry: true
+      helixRepo: dotnet/standard
+      jobs:
+      - job: Windows_NT
         pool: 
-          name: Hosted Ubuntu 1604
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCorePublic-Pool
+            queue: buildpool.windows.10.amd64.vs2017.open
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: NetCoreInternal-Pool
+            queue: buildpool.windows.10.amd64.vs2017
+        variables:
+        # Enable signing for internal, non-PR builds
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - group: DotNet-Blob-Feed
+          - group: DotNet-Symbol-Server-Pats
+          - name: _SignType
+            value: Real
+          - name: _DotNetPublishToBlobFeed
+            value: true
+          - name: _BuildArgs
+            value: /p:SignType=$(_SignType)
+              /p:DotNetSignType=$(_SignType)
+              /p:MicroBuild_SigningEnabled=true 
+              /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+              /p:TeamName=$(_TeamName)
+              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+              /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+              /p:DotNetPublishToBlobFeed=true
+              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          - name: _OfficialBuildIdArgs
+        # else
+        - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          - name: _SignType
+            value: Test
+          - name: _BuildArgs
+            value: /p:SignType=$(_SignType)
         strategy:
           matrix:
             Debug:
               _BuildConfig: Debug
             Release:
               _BuildConfig: Release
-        variables:
-        - name: _SignType
-          value: Test
         steps:
         - checkout: self
           clean: true
-        - script: eng/common/cibuild.sh
-            --configuration $(_BuildConfig)
-            --prepareMachine
-          displayName: Linux Build
+        - script: eng\common\cibuild.cmd
+            -configuration $(_BuildConfig) 
+            -prepareMachine
+            -warnaserror:0
+            $(_BuildArgs)
+          displayName: Windows Build / Publish
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates\post-build\post-build.yml
-    parameters:
-      # Symbol validation isn't being very reliable lately. This should be enabled back
-      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
-      enableSymbolValidation: false
+      # Linux leg (only runs in CI)
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - job: Linux
+          pool: 
+            name: Hosted Ubuntu 1604
+          strategy:
+            matrix:
+              Debug:
+                _BuildConfig: Debug
+              Release:
+                _BuildConfig: Release
+          variables:
+          - name: _SignType
+            value: Test
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng/common/cibuild.sh
+              --configuration $(_BuildConfig)
+              --prepareMachine
+            displayName: Linux Build
+
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: eng\common\templates\post-build\post-build.yml
+      parameters:
+        # Symbol validation isn't being very reliable lately. This should be enabled back
+        # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
+        enableSymbolValidation: false

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -105,7 +105,7 @@ stages:
             displayName: Linux Build
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: eng/common/templates/post-build/post-build.yml
+    - template: /eng/common/templates/post-build/post-build.yml
       parameters:
         # Symbol validation isn't being very reliable lately. This should be enabled back
         # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -104,9 +104,9 @@ stages:
               --prepareMachine
             displayName: Linux Build
 
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/post-build/post-build.yml
-      parameters:
-        # Symbol validation isn't being very reliable lately. This should be enabled back
-        # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
-        enableSymbolValidation: false
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: /eng/common/templates/post-build/post-build.yml
+    parameters:
+      # Symbol validation isn't being very reliable lately. This should be enabled back
+      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
+      enableSymbolValidation: false

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -100,3 +100,10 @@ jobs:
             --configuration $(_BuildConfig)
             --prepareMachine
           displayName: Linux Build
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng\common\templates\post-build\post-build.yml
+    parameters:
+      # Symbol validation isn't being very reliable lately. This should be enabled back
+      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
+      enableSymbolValidation: false

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -105,7 +105,7 @@ stages:
             displayName: Linux Build
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: eng\common\templates\post-build\post-build.yml
+    - template: eng/common/templates/post-build/post-build.yml
       parameters:
         # Symbol validation isn't being very reliable lately. This should be enabled back
         # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871


### PR DESCRIPTION
Ensures that we won't lose publishing when we disable the release pipeline