### PR TITLE
Do not update XLF during design-time or LUT builds

### DIFF
--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -40,6 +40,18 @@
     <_IsInnerXlfBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' != ''">true</_IsInnerXlfBuild>
   </PropertyGroup>
 
+  <!-- Suppress execution in certain contexts -->
+  <PropertyGroup>
+    <!-- In the normal case, run before the 'BeforeBuild' target -->
+    <_UpdateXlfOnBuildBeforeTargets Condition="'$(_UpdateXlfOnBuildBeforeTargets)' == ''">BeforeBuild</_UpdateXlfOnBuildBeforeTargets>
+    <!-- Do not run as part of live unit testing -->
+    <_UpdateXlfOnBuildBeforeTargets Condition="'$(BuildingForLiveUnitTesting)' == 'true'"></_UpdateXlfOnBuildBeforeTargets>
+    <!-- Do not run during CPS/MLPS design-time builds -->
+    <_UpdateXlfOnBuildBeforeTargets Condition="'$(DesignTimeBuild)' == 'true'"></_UpdateXlfOnBuildBeforeTargets>
+    <!-- Do not run during legacy design-time builds -->
+    <_UpdateXlfOnBuildBeforeTargets Condition="'$(BuildingProject)' == 'false'"></_UpdateXlfOnBuildBeforeTargets>
+  </PropertyGroup>
+
   <!-- Updates the list of XlfSource items that drives incremental update (see above) -->
   <Target Name="UpdateXlfSourceList"
           DependsOnTargets="GetXlfSources">
@@ -58,7 +70,7 @@
 
   <Target Name="UpdateXlfOnBuild"
           Condition="'$(EnableXlfLocalization)' == 'true' and '$(UpdateXlfOnBuild)' == 'true' and '$(_IsInnerXlfBuild)' != 'true'"
-          BeforeTargets="BeforeBuild"
+          BeforeTargets="$(_UpdateXlfOnBuildBeforeTargets)"
           DependsOnTargets="UpdateXlf"
           />
 

--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -30,26 +30,29 @@
     <XlfIntermediateOutputPath Condition="'$(XlfIntermediateOutputPath)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).xlf\</XlfIntermediateOutputPath>
     <_XlfSourceList>$(XlfIntermediateOutputPath)XlfSources.txt</_XlfSourceList>
     <_UpdateXlfLastRun>$(XlfIntermediateOutputPath)UpdateXlf.lastrun</_UpdateXlfLastRun>
-
-    <!--
-      This is an "inner build" of a cross-targeted project if there are multiple target frameworks, but 
-      we're instantiated with a single one. We musn't trigger an update  of .xlf source files on inner build
-      because inner builds happen in parallel, which would cause a race when modifying the same files. Instead,
-      there is an outer build trigger that calls inner UpdateXlf serially.
-    -->
-    <_IsInnerXlfBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' != ''">true</_IsInnerXlfBuild>
   </PropertyGroup>
 
-  <!-- Suppress execution in certain contexts -->
+  <!--
+    Suppress execution in certain contexts
+  -->
   <PropertyGroup>
-    <!-- In the normal case, run before the 'BeforeBuild' target -->
-    <_UpdateXlfOnBuildBeforeTargets Condition="'$(_UpdateXlfOnBuildBeforeTargets)' == ''">BeforeBuild</_UpdateXlfOnBuildBeforeTargets>
+    <_SuppressUpdateXlfOnBuild>false</_SuppressUpdateXlfOnBuild>
+    <!-- Suppress if not XLF localization not enabled -->
+    <_SuppressUpdateXlfOnBuild Condition="'$(EnableXlfLocalization)' != 'true'">true</_SuppressUpdateXlfOnBuild>
+    <!-- Suppress if not opted in -->
+    <_SuppressUpdateXlfOnBuild Condition="'$(UpdateXlfOnBuild)' != 'true'">true</_SuppressUpdateXlfOnBuild>
+    <!--
+      Suppress if this is an "inner build" of a cross-targeted project. In such a case there are multiple target
+      frameworks, but we're instantiated with a single one. Inner builds occur in parallel so we cannot update
+      .xlf source files without file modification races. Instead, the outer build calls inner UpdateXlf serially.
+    -->
+    <_SuppressUpdateXlfOnBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' != ''">true</_SuppressUpdateXlfOnBuild>
     <!-- Do not run as part of live unit testing -->
-    <_UpdateXlfOnBuildBeforeTargets Condition="'$(BuildingForLiveUnitTesting)' == 'true'"></_UpdateXlfOnBuildBeforeTargets>
+    <_SuppressUpdateXlfOnBuild Condition="'$(BuildingForLiveUnitTesting)' == 'true'">true</_SuppressUpdateXlfOnBuild>
     <!-- Do not run during CPS/MLPS design-time builds -->
-    <_UpdateXlfOnBuildBeforeTargets Condition="'$(DesignTimeBuild)' == 'true'"></_UpdateXlfOnBuildBeforeTargets>
+    <_SuppressUpdateXlfOnBuild Condition="'$(DesignTimeBuild)' == 'true'">true</_SuppressUpdateXlfOnBuild>
     <!-- Do not run during legacy design-time builds -->
-    <_UpdateXlfOnBuildBeforeTargets Condition="'$(BuildingProject)' == 'false'"></_UpdateXlfOnBuildBeforeTargets>
+    <_SuppressUpdateXlfOnBuild Condition="'$(BuildingProject)' == 'false'">true</_SuppressUpdateXlfOnBuild>
   </PropertyGroup>
 
   <!-- Updates the list of XlfSource items that drives incremental update (see above) -->
@@ -69,8 +72,8 @@
   </Target>
 
   <Target Name="UpdateXlfOnBuild"
-          Condition="'$(EnableXlfLocalization)' == 'true' and '$(UpdateXlfOnBuild)' == 'true' and '$(_IsInnerXlfBuild)' != 'true'"
-          BeforeTargets="$(_UpdateXlfOnBuildBeforeTargets)"
+          Condition="'$(_SuppressUpdateXlfOnBuild)' != 'true'"
+          BeforeTargets="BeforeBuild"
           DependsOnTargets="UpdateXlf"
           />
 


### PR DESCRIPTION
Suppresses the update of XLF files during LUT (live unit testing) and DTB (design-time builds).

Fixes #36.
Fixes #233.
Relates to https://github.com/dotnet/project-system/issues/5653.

---

This is untested as I cannot get this repo to build on my workstation. Running `restore.cmd` gives:

```text
at GetDotNetInstallScript, D:\repos\xliff-tasks\eng\common\tools.ps1: line 170
at InstallDotNetSharedFramework, D:\repos\xliff-tasks\eng\restore-toolset.ps1: line 27
at InitializeCustomSDKToolset, D:\repos\xliff-tasks\eng\restore-toolset.ps1: line 19
at <ScriptBlock>, D:\repos\xliff-tasks\eng\restore-toolset.ps1: line 36
at InitializeCustomToolset, D:\repos\xliff-tasks\eng\common\build.ps1: line 75
at Build, D:\repos\xliff-tasks\eng\common\build.ps1: line 81
at <ScriptBlock>, D:\repos\xliff-tasks\eng\common\build.ps1: line 140
at <ScriptBlock>, <No file>: line 1
(NETCORE_ENGINEERING_TELEMETRY=InitializeToolset) Access to the path 'C:\Program Files\dotnet\dotnet-install.ps1' is denied.
```