### PR TITLE
Do not check for out-of-date XLF in design-time builds

### DIFF
--- a/src/XliffTasks/build/XliffTasks.targets
+++ b/src/XliffTasks/build/XliffTasks.targets
@@ -63,7 +63,7 @@
           />
 
   <Target Name="EnsureXlfIsUpToDate"
-          Condition="'$(ErrorOnOutOfDateXlf)' == 'true'"
+          Condition="'$(ErrorOnOutOfDateXlf)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(BuildingProject)' != 'false'"
           DependsOnTargets="_DisallowXlfModification;_UpdateXlf"
           />
 


### PR DESCRIPTION
We wouldn't ordinarily be pulled into a design-time build, but in some circumstances additional build customization might pull in a target that would trigger us to run in a design-time build. If that happens, do not enforce that XLF is up to date for several reasons:

1. It can be relatively slow and the validation can wait until a real build.

2. The eventual real build may be configured to update-on-build, making any error from design-time-build false positives.

3. Any error in the design time build without ContinueOnError will stop it from making critical progress. (We could fix this one with the appropriate continue on error, but we'd still have the above.)

Fix #36 
Fix #233