### PR TITLE
Add arcade-powered source-build basic configuration

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>xliff-tasks</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+</Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,0 +1,5 @@
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="*/*" />
+  </IgnorePatterns>
+</UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,5 +7,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>f6ed3308865528c56ed26b85004121fce56bf4f4</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="5.0.0-alpha.1.20473.1">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>def2e2c6dc5064319250e2868a041a3dc07f9579</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
This adds the basic arcade-powered source-build configuration. I ran this with `./build.sh -c Release --restore --build --pack /p:ArcadeBuildFromSource=true`.

No patches necessary. There was only one in dotnet/source-build, a legacy feed removal that already happened here. :+1:


---

(Edit: adding some general text written later that might help put the PR in context a little better:)

This PR adds the local build infrastructure that lets ArPow (arcade-powered source-build) run in this repo. See <https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/onboarding/local-onboarding.md> for more details about how it works.

To try it out locally, run this on Linux: `./build.sh -c Release --restore --build --pack /p:ArcadeBuildFromSource=true -bl`

This PR should have no effect on ordinary builds, or CI. ArPow stage 2 will add source-build to CI: PR validation and official builds.

For <https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/implementation-plan.md>
