### PR TITLE
Remove restoresources from versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,18 +23,4 @@
     <SystemReflectionTypeExtensionsVersion>4.3.0</SystemReflectionTypeExtensionsVersion>
     <StrongNameKeyId>MicrosoftAspNet</StrongNameKeyId>
   </PropertyGroup>
-  <PropertyGroup>
-    <RestoreSources>
-      $(RestoreSources);
-      https://dotnet.myget.org/F/msbuild/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-      https://dotnet.myget.org/F/system-commandline/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json;
-      https://myget.org/F/vs-devcore/api/v3/index.json;
-      https://myget.org/F/vs-editor/api/v3/index.json;
-      https://vside.myget.org/F/vssdk/api/v3/index.json;
-      https://vside.myget.org/F/vs-impl/api/v3/index.json;
-    </RestoreSources>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Remove the restoreSources node in versions.props. It looks like we don't need any of these feeds judging by this test official build:

https://dnceng.visualstudio.com/internal/_build/results?buildId=839791&view=results

fixes https://github.com/dotnet/xliff-tasks/issues/368