### PR TITLE
Support translation of SearchTerms

### DIFF
--- a/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
+++ b/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
@@ -24,6 +24,11 @@ namespace XliffTasks.Tests
     <EnumValue Name=""Third"" DisplayName=""Do the third thing"" />
   </EnumProperty>
   <BoolProperty Name=""MyBoolProperty"" Description=""My bool property description."" />
+  <StringProperty Name=""MyStringProperty"">
+    <StringProperty.Metadata>
+      <NameValuePair Name=""SearchTerms"" Value=""My;Search;Terms"" />
+    </StringProperty.Metadata>
+  </StringProperty>
 </Rule>";
 
             var translations = new Dictionary<string, string>
@@ -37,7 +42,7 @@ namespace XliffTasks.Tests
                 ["EnumValue|MyEnumProperty.Second|DisplayName"] = "GGG",
                 ["EnumValue|MyEnumProperty.Third|DisplayName"] = "HHH",
                 ["BoolProperty|MyBoolProperty|Description"] = "III",
-                
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms"] = "JJJ"
             };
 
             string expectedTranslation =
@@ -51,6 +56,11 @@ namespace XliffTasks.Tests
     <EnumValue Name=""Third"" DisplayName=""HHH"" />
   </EnumProperty>
   <BoolProperty Name=""MyBoolProperty"" Description=""III"" />
+  <StringProperty Name=""MyStringProperty"">
+    <StringProperty.Metadata>
+      <NameValuePair Name=""SearchTerms"" Value=""JJJ"" />
+    </StringProperty.Metadata>
+  </StringProperty>
 </Rule>";
 
             var document = new XamlRuleDocument();

--- a/src/XliffTasks/Model/XamlRuleDocument.cs
+++ b/src/XliffTasks/Model/XamlRuleDocument.cs
@@ -18,21 +18,29 @@ namespace XliffTasks.Model
             {
                 foreach (var attribute in element.Attributes())
                 {
-                    if (XmlName(attribute) != "DisplayName" && XmlName(attribute) != "Description")
+                    if (XmlName(attribute) == "DisplayName"
+                        || XmlName(attribute) == "Description")
                     {
-                        continue;
+                        yield return new TranslatableXmlAttribute(
+                            id: GenerateIdForDisplayNameOrDescription(attribute),
+                            source: attribute.Value,
+                            note: null,
+                            attribute: attribute);
                     }
-
-                    yield return new TranslatableXmlAttribute(
-                        id: GenerateId(attribute),
-                        source: attribute.Value,
-                        note: null,
-                        attribute: attribute);
+                    else if (XmlName(attribute) == "Value"
+                        && AttributedName(element) == "SearchTerms")
+                    {
+                        yield return new TranslatableXmlAttribute(
+                            id: GenerateIdForPropertyMetadata(element),
+                            source: attribute.Value,
+                            note: null,
+                            attribute: attribute);
+                    }
                 }
             }
         }
 
-        private static string GenerateId(XAttribute attribute)
+        private static string GenerateIdForDisplayNameOrDescription(XAttribute attribute)
         {
             XElement parent = attribute.Parent;
 
@@ -43,6 +51,13 @@ namespace XliffTasks.Model
             }
 
             return $"{XmlName(parent)}|{AttributedName(parent)}|{XmlName(attribute)}";
+        }
+
+        private static string GenerateIdForPropertyMetadata(XElement element)
+        {
+            XElement grandParent = element.Parent.Parent;
+
+            return $"{XmlName(grandParent)}|{AttributedName(grandParent)}|Metadata|{AttributedName(element)}";
         }
 
         private static string XmlName(XElement element) => element.Name.LocalName;


### PR DESCRIPTION
Support translation of `SearchTerms` metadata on properties in CPS rules stored in .xaml format. If we find an attribute named "Value" and it has a sibling attribute named "Name" with a value "SearchTerms", we assume we are looking at the `SearchTerms` metadata on a property.

These search terms are ultimately used by the new property pages UI to support user searches, so we need to be able to localize the terms.