### PR TITLE
Add local + ci for source-build build infra

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,23 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>xliff-tasks</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+  <Target Name="ApplySourceBuildPatchFiles"
+          Condition="
+            '$(ArcadeBuildFromSource)' == 'true' and
+            '$(ArcadeInnerBuildFromSource)' == 'true'"
+          BeforeTargets="Execute">
+    <ItemGroup>
+      <SourceBuildPatchFile Include="$(RepositoryEngineeringDir)source-build-patches\*.patch" />
+    </ItemGroup>
+
+    <Exec
+      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+      WorkingDirectory="$(RepoRoot)"
+      Condition="'@(SourceBuildPatchFile)' != ''" />
+  </Target>
+
+</Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,0 +1,5 @@
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="*/*" />
+  </IgnorePatterns>
+</UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,6 +6,7 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21105.12">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>938b3e8b4edcd96ca0f0cbbae63c87b3f51f7afe</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -25,6 +25,7 @@ stages:
       enablePublishTestResults: false
       enablePublishBuildAssets: true
       enablePublishUsingPipelines: $(_PublishUsingPipelines)
+      enableSourceBuild: true
       enableTelemetry: true
       helixRepo: dotnet/standard
       jobs:

--- a/eng/source-build-patches/0001-remove-netcoreapp2.1-targets.patch
+++ b/eng/source-build-patches/0001-remove-netcoreapp2.1-targets.patch
@@ -1,0 +1,54 @@
+From 61101604c89260e680df2d0e52c2dce84629ba00 Mon Sep 17 00:00:00 2001
+From: Tom Deseyn <tom.deseyn@gmail.com>
+Date: Thu, 19 Nov 2020 20:06:23 +0100
+Subject: [PATCH] xliff-tasks: remove netcoreapp2.1 targets
+
+---
+ src/XliffTasks/XliffTasks.csproj        | 6 ++----
+ src/XliffTasks/build/XliffTasks.targets | 2 +-
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/src/XliffTasks/XliffTasks.csproj b/src/XliffTasks/XliffTasks.csproj
+index d967ac3..340b458 100644
+--- a/src/XliffTasks/XliffTasks.csproj
++++ b/src/XliffTasks/XliffTasks.csproj
+@@ -4,10 +4,9 @@
+ 
+   <PropertyGroup>
+     <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
+-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net5.0</TargetFrameworks>
+     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
+     <EnableDefaultItems>false</EnableDefaultItems>
+-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+     <IsPackable>true</IsPackable>
+     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+     <LangVersion>7.2</LangVersion>
+@@ -23,10 +22,9 @@
+     <InternalsVisibleTo Include="XliffTasks.Tests" />
+   </ItemGroup>
+ 
+-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
++  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+     <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" PrivateAssets="All" />
+     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" PrivateAssets="All" />
+-    <PackageReference Include="Microsoft.NETCore.App" Version="2.0.0" PrivateAssets="All" />
+   </ItemGroup>
+ 
+   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+diff --git a/src/XliffTasks/build/XliffTasks.targets b/src/XliffTasks/build/XliffTasks.targets
+index a79dae2..d5498c2 100644
+--- a/src/XliffTasks/build/XliffTasks.targets
++++ b/src/XliffTasks/build/XliffTasks.targets
+@@ -4,7 +4,7 @@
+ <Project>
+ 
+   <PropertyGroup>
+-    <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\</XliffTasksDirectory>
++    <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net5.0\</XliffTasksDirectory>
+     <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net46\</XliffTasksDirectory>
+     <XliffTasksAssembly>$(XliffTasksDirectory)XliffTasks.dll</XliffTasksAssembly>
+   </PropertyGroup>
+-- 
+2.26.2
+


### PR DESCRIPTION
This enables 'source-build', which makes it easier to build the entire shipping .NET SDK from source.

This is the first and second step of arcade-powered-source-build:
https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/README.md

See https://github.com/dotnet/xdt/pull/352 for a similar PR, that this is based on.