### PR TITLE
Support XLF comments in XAML rule files

### DIFF
--- a/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
+++ b/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
@@ -14,22 +14,94 @@ namespace XliffTasks.Tests
         public void BasicLoadAndTranslate()
         {
             string source =
-@"<Rule Name=""MyRule"" DisplayName=""My rule display name"" PageTemplate=""generic"" Description=""My rule description"" xmlns=""http://schemas.microsoft.com/build/2009/properties"">
+@"<Rule Name=""MyRule""
+        DisplayName=""My rule display name""
+        PageTemplate=""generic""
+        Description=""My rule description""
+        xmlns=""http://schemas.microsoft.com/build/2009/properties"">
+  <!-- DisplayName: My rule display name comment -->
+  <!-- Description: My rule description comment -->
   <Rule.Categories>
-    <Category Name=""MyCategory"" DisplayName=""My category display name"" />
+    <Category Name=""MyCategory"" DisplayName=""My category display name"">
+      <!-- DisplayName: My category display name comment -->
+    </Category>
   </Rule.Categories>
   <EnumProperty Name=""MyEnumProperty"" DisplayName=""My enum property display name"" Category=""MyCategory"" Description=""Specifies the source file will be copied to the output directory."">
-    <EnumValue Name=""First"" DisplayName=""Do the first thing"" />
+    <!-- DisplayName: My enum property display name comment -->
+    <!-- Description: My enum property description comment -->
+    <EnumValue Name=""First"" DisplayName=""Do the first thing"">
+      <!-- DisplayName: My first item comment -->
+    </EnumValue>
     <EnumValue Name=""Second"" DisplayName=""Do the second thing"" />
     <EnumValue Name=""Third"" DisplayName=""Do the third thing"" />
   </EnumProperty>
   <BoolProperty Name=""MyBoolProperty"" Description=""My bool property description."" />
   <StringProperty Name=""MyStringProperty"">
     <StringProperty.Metadata>
-      <NameValuePair Name=""SearchTerms"" Value=""My;Search;Terms"" />
+      <NameValuePair Name=""SearchTerms"" Value=""My;Search;Terms"">
+        <!-- Value: My search terms comment -->
+      </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>
 </Rule>";
+
+            string expectedXlf =
+@"<xliff xmlns=""urn:oasis:names:tc:xliff:document:1.2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" version=""1.2"" xsi:schemaLocation=""urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd"">
+  <file datatype=""xml"" source-language=""en"" target-language=""fr"" original=""test.xaml"">
+    <body>
+      <trans-unit id=""BoolProperty|MyBoolProperty|Description"">
+        <source>My bool property description.</source>
+        <target state=""new"">My bool property description.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Category|MyCategory|DisplayName"">
+        <source>My category display name</source>
+        <target state=""new"">My category display name</target>
+        <note>My category display name comment</note>
+      </trans-unit>
+      <trans-unit id=""EnumProperty|MyEnumProperty|Description"">
+        <source>Specifies the source file will be copied to the output directory.</source>
+        <target state=""new"">Specifies the source file will be copied to the output directory.</target>
+        <note>My enum property description comment</note>
+      </trans-unit>
+      <trans-unit id=""EnumProperty|MyEnumProperty|DisplayName"">
+        <source>My enum property display name</source>
+        <target state=""new"">My enum property display name</target>
+        <note>My enum property display name comment</note>
+      </trans-unit>
+      <trans-unit id=""EnumValue|MyEnumProperty.First|DisplayName"">
+        <source>Do the first thing</source>
+        <target state=""new"">Do the first thing</target>
+        <note>My first item comment</note>
+      </trans-unit>
+      <trans-unit id=""EnumValue|MyEnumProperty.Second|DisplayName"">
+        <source>Do the second thing</source>
+        <target state=""new"">Do the second thing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""EnumValue|MyEnumProperty.Third|DisplayName"">
+        <source>Do the third thing</source>
+        <target state=""new"">Do the third thing</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""Rule|MyRule|Description"">
+        <source>My rule description</source>
+        <target state=""new"">My rule description</target>
+        <note>My rule description comment</note>
+      </trans-unit>
+      <trans-unit id=""Rule|MyRule|DisplayName"">
+        <source>My rule display name</source>
+        <target state=""new"">My rule display name</target>
+        <note>My rule display name comment</note>
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|Metadata|SearchTerms"">
+        <source>My;Search;Terms</source>
+        <target state=""new"">My;Search;Terms</target>
+        <note>My search terms comment</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>";
 
             var translations = new Dictionary<string, string>
             {
@@ -47,18 +119,28 @@ namespace XliffTasks.Tests
 
             string expectedTranslation =
 @"<Rule Name=""MyRule"" DisplayName=""AAA"" PageTemplate=""generic"" Description=""BBB"" xmlns=""http://schemas.microsoft.com/build/2009/properties"">
+  <!-- DisplayName: My rule display name comment -->
+  <!-- Description: My rule description comment -->
   <Rule.Categories>
-    <Category Name=""MyCategory"" DisplayName=""CCC"" />
+    <Category Name=""MyCategory"" DisplayName=""CCC"">
+      <!-- DisplayName: My category display name comment -->
+    </Category>
   </Rule.Categories>
   <EnumProperty Name=""MyEnumProperty"" DisplayName=""DDD"" Category=""MyCategory"" Description=""EEE"">
-    <EnumValue Name=""First"" DisplayName=""FFF"" />
+    <!-- DisplayName: My enum property display name comment -->
+    <!-- Description: My enum property description comment -->
+    <EnumValue Name=""First"" DisplayName=""FFF"">
+      <!-- DisplayName: My first item comment -->
+    </EnumValue>
     <EnumValue Name=""Second"" DisplayName=""GGG"" />
     <EnumValue Name=""Third"" DisplayName=""HHH"" />
   </EnumProperty>
   <BoolProperty Name=""MyBoolProperty"" Description=""III"" />
   <StringProperty Name=""MyStringProperty"">
     <StringProperty.Metadata>
-      <NameValuePair Name=""SearchTerms"" Value=""JJJ"" />
+      <NameValuePair Name=""SearchTerms"" Value=""JJJ"">
+        <!-- Value: My search terms comment -->
+      </NameValuePair>
     </StringProperty.Metadata>
   </StringProperty>
 </Rule>";
@@ -66,10 +148,20 @@ namespace XliffTasks.Tests
             var document = new XamlRuleDocument();
             var writer = new StringWriter();
             document.Load(new StringReader(source));
+
+            var xliffDocument = new XlfDocument();
+            xliffDocument.LoadNew("fr");
+            xliffDocument.Update(document, "test.xaml");
+
             document.Translate(translations);
             document.Save(writer);
 
             AssertEx.EqualIgnoringLineEndings(expectedTranslation, writer.ToString());
+
+            var xliffWriter = new StringWriter();
+            xliffDocument.Save(xliffWriter);
+
+            AssertEx.EqualIgnoringLineEndings(expectedXlf, xliffWriter.ToString());
         }
     }
 }

--- a/src/XliffTasks.Tests/XliffTasks.Tests.csproj
+++ b/src/XliffTasks.Tests/XliffTasks.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/XliffTasks/XliffTasks.csproj
+++ b/src/XliffTasks/XliffTasks.csproj
@@ -10,7 +10,7 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8</LangVersion>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <AssemblyName>Microsoft.DotNet.XliffTasks</AssemblyName>
     <RootNamespace>XliffTasks</RootNamespace>


### PR DESCRIPTION
RESX files have a natural "comment" field that maps to the TranslatableNode.Note. For XAML rule files, there has been no such obvious way to support adding these kinds of comments for translators.

It's useful to be able to leave comments about particular translatable strings for localisation.

I couldn't find a better way of adding these notes than via XML comments. I tried using attached properties and using mc:Ignorable, but it caused the Project Properties UI to fail to load pages with these attributes. So instead I settled for this non-type-safe approach.