### PR TITLE
Enable TSA publish when using CodeQL

### DIFF
--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -44,4 +44,4 @@ stages:
               -TsaIterationPath $(_TsaIterationPath)
               -TsaRepositoryName "xliff-tasks"
               -TsaCodebaseName "xliff-tasks"
-              -TsaPublish $False'
+              -TsaPublish $True'


### PR DESCRIPTION
Enable publishing to TSA when the CodeQL pipeline is run.