### PR TITLE
Remove unused source-build ApplySourceBuildPatchFiles target

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -5,19 +5,4 @@
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
 
-  <Target Name="ApplySourceBuildPatchFiles"
-          Condition="
-            '$(ArcadeBuildFromSource)' == 'true' and
-            '$(ArcadeInnerBuildFromSource)' == 'true'"
-          BeforeTargets="Execute">
-    <ItemGroup>
-      <SourceBuildPatchFile Include="$(RepositoryEngineeringDir)source-build-patches\*.patch" />
-    </ItemGroup>
-
-    <Exec
-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
-      WorkingDirectory="$(RepoRoot)"
-      Condition="'@(SourceBuildPatchFile)' != ''" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
This is no longer used after https://github.com/dotnet/xliff-tasks/pull/509.  No source-build patches should ever be made in the future therefore this target should get cleaned up.