### PR TITLE
Downgrade the Microsoft.NETCore.App reference to 2.0.0

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,5 +1,5 @@
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="*/*" />
+    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,5 +8,15 @@
       <Sha>258a37cd6a7884f771d0f991d9f24d29e292abd0</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22356.1">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>2288850ad99cac4de5968ed609144bfdc81567ce</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22423-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha>0bba6b2d342056cb3fb3906f25929a92e063c5f8</Sha>
+      <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,9 +13,9 @@
       <Sha>2288850ad99cac4de5968ed609144bfdc81567ce</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22423-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22424-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
-      <Sha>0bba6b2d342056cb3fb3906f25929a92e063c5f8</Sha>
+      <Sha>e57efa1ed395dd6975b33052719facb24f03ee0b</Sha>
       <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>

--- a/src/XliffTasks/XliffTasks.csproj
+++ b/src/XliffTasks/XliffTasks.csproj
@@ -29,7 +29,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.Build.Framework" Version="15.1.1012" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.1012" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/xliff-tasks/issues/650
Fixes https://github.com/dotnet/source-build/issues/2201

This PR does two things

1. Downgrade the Microsoft.NETCore.App from 2.2.8 to 2.0.0.  Since 2.2 is EOL, it shouldn't be referenced.  2.0.0 is something compatible with source-build.  https://github.com/dotnet/xliff-tasks/issues/657 tracks a long term solution which would remove this dependency all together.
2. Enable source-build prebuilt detection.  This would have caught this issue before it was checked in.