### PR TITLE
Use CodeQL 3000 instead of Guardian

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{  
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Fundamentals\\Infrastructure\\Arcade\\SDL",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "dnceng@microsoft.com" ],
+    "repositoryName":"xliff-tasks",
+    "codebaseName": "xliff-tasks"
+}

--- a/eng/azure-pipelines-codeql.yml
+++ b/eng/azure-pipelines-codeql.yml
@@ -1,47 +1,52 @@
+parameters:
+  # Optionally do not publish to TSA. Useful for e.g. verifying fixes before PR.
+- name: Codeql.TSAEnabled
+  displayName: Publish results to TSA
+  type: boolean
+  default: true
+
 variables:
-  - name: _TeamName
-    value: DotNetCore
-  - group: SDL_Settings
-    
+  # CG is handled in the primary CI pipeline
+- name: skipComponentGovernanceDetection
+  value: true
+  # Force CodeQL enabled so it may be run on any branch
+- name: Codeql.Enabled
+  value: true
+  # Do not let CodeQL 3000 Extension gate scan frequency
+- name: Codeql.Cadence
+  value: 0
+- name: _BuildConfig
+  value: Release
+
 trigger: none
 
 schedules:
   - cron: 0 12 * * 1
-    displayName: Weekly Monday CodeQL/Semmle run
+    displayName: Weekly Monday CodeQL run
     branches:
       include:
       - main
     always: true
 
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - template: /eng/common/templates/jobs/codeql-build.yml
-    parameters:
-      jobs:
-      - job: Windows_NT_CSharp
-        timeoutInMinutes: 90
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2019.amd64
+pool:
+  name: NetCore1ESPool-Internal
+  demands: ImageOverride -equals 1es-windows-2022
 
-        steps:
-        - checkout: self
-          clean: true
+steps:
+- task: CodeQL3000Init@0
+  displayName: CodeQL Initialize
 
-        - template: /eng/common/templates/steps/execute-codeql.yml
-          parameters:
-            executeAllSdlToolsScript: 'eng/common/sdl/execute-all-sdl-tools.ps1'
-            buildCommands: 'eng\common\cibuild.cmd -configuration Release -prepareMachine /p:Test=false /p:Sign=false'
-            language: csharp
-            additionalParameters: '-SourceToolsList @("semmle")
-              -TsaInstanceURL $(_TsaInstanceURL)
-              -TsaProjectName $(_TsaProjectName)
-              -TsaNotificationEmail $(_TsaNotificationEmail)
-              -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-              -TsaBugAreaPath $(_TsaBugAreaPath)
-              -TsaIterationPath $(_TsaIterationPath)
-              -TsaRepositoryName "xliff-tasks"
-              -TsaCodebaseName "xliff-tasks"
-              -TsaPublish $True'
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    useGlobalJson: true
+
+- script: eng\common\cibuild.cmd
+    -configuration $(_BuildConfig)
+    -prepareMachine
+    -warnaserror:0
+  displayName: Windows Build / Publish
+
+
+- task: CodeQL3000Finalize@0
+  displayName: CodeQL Finalize


### PR DESCRIPTION
Swap Guardian for CodeQL 3000 Azure DevOps extension for CodeQL static code analysis.

Successful test build (minus TSA publish): [Pipelines - Run 2012777](https://dev.azure.com/dnceng/internal/_build/results?buildId=2012777&view=results)

Part of dotnet/arcade#11151