### PR TITLE
Allow arbitrary properties with a "Value" to be translatable

### DIFF
--- a/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
+++ b/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
@@ -134,7 +134,7 @@ namespace XliffTasks.Tests
                 ["EnumValue|MyEnumProperty.Third|DisplayName"] = "HHH",
                 ["BoolProperty|MyBoolProperty|Description"] = "III",
                 ["StringProperty|MyStringProperty|Metadata|SearchTerms"] = "JJJ",
-                ["StringProperty|MyStringProperty|Metadata|TypeDescriptorText|Value"] = "KKK",
+                ["StringProperty|MyStringProperty|Metadata|TypeDescriptorText|Value"] = "NNN",
                 ["StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp1"] = "LLL",
                 ["StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp2"] = "MMM",
             };
@@ -160,7 +160,7 @@ namespace XliffTasks.Tests
   <BoolProperty Name=""MyBoolProperty"" Description=""III"" />
   <StringProperty Name=""MyStringProperty"">
     <StringProperty.Metadata>
-      <NameValuePair Name=""TypeDescriptorText"" Value=""KKK"" xliff:LocalizedProperties=""Value"">
+      <NameValuePair Name=""TypeDescriptorText"" Value=""NNN"" xliff:LocalizedProperties=""Value"">
         <!-- Value: My type descriptor text comment -->
       </NameValuePair>
       <NameValuePair Name=""SearchTerms"" Value=""JJJ"" TranslatableProp1=""LLL"" TranslatableProp2=""MMM"" NonTranslatableProp3=""same"" xliff:LocalizedProperties=""TranslatableProp1;TranslatableProp2"">

--- a/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
+++ b/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
@@ -18,7 +18,8 @@ namespace XliffTasks.Tests
         DisplayName=""My rule display name""
         PageTemplate=""generic""
         Description=""My rule description""
-        xmlns=""http://schemas.microsoft.com/build/2009/properties"">
+        xmlns=""http://schemas.microsoft.com/build/2009/properties"" xmlns:xliff=""https://github.com/dotnet/xliff-tasks"" xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+        mc:Ignorable=""xliff"">
   <!-- DisplayName: My rule display name comment -->
   <!-- Description: My rule description comment -->
   <Rule.Categories>
@@ -38,6 +39,9 @@ namespace XliffTasks.Tests
   <BoolProperty Name=""MyBoolProperty"" Description=""My bool property description."" />
   <StringProperty Name=""MyStringProperty"">
     <StringProperty.Metadata>
+      <NameValuePair Name=""TypeDescriptorText"" Value=""Custom symbols"" xliff:IsTranslatable=""true"">
+        <!-- Value: My type descriptor text comment -->
+      </NameValuePair>
       <NameValuePair Name=""SearchTerms"" Value=""My;Search;Terms"">
         <!-- Value: My search terms comment -->
       </NameValuePair>
@@ -99,6 +103,11 @@ namespace XliffTasks.Tests
         <target state=""new"">My;Search;Terms</target>
         <note>My search terms comment</note>
       </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|Metadata|TypeDescriptorText"">
+        <source>Custom symbols</source>
+        <target state=""new"">Custom symbols</target>
+        <note>My type descriptor text comment</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>";
@@ -114,11 +123,12 @@ namespace XliffTasks.Tests
                 ["EnumValue|MyEnumProperty.Second|DisplayName"] = "GGG",
                 ["EnumValue|MyEnumProperty.Third|DisplayName"] = "HHH",
                 ["BoolProperty|MyBoolProperty|Description"] = "III",
-                ["StringProperty|MyStringProperty|Metadata|SearchTerms"] = "JJJ"
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms"] = "JJJ",
+                ["StringProperty|MyStringProperty|Metadata|TypeDescriptorText"] = "KKK",
             };
 
             string expectedTranslation =
-@"<Rule Name=""MyRule"" DisplayName=""AAA"" PageTemplate=""generic"" Description=""BBB"" xmlns=""http://schemas.microsoft.com/build/2009/properties"">
+@"<Rule Name=""MyRule"" DisplayName=""AAA"" PageTemplate=""generic"" Description=""BBB"" xmlns=""http://schemas.microsoft.com/build/2009/properties"" xmlns:xliff=""https://github.com/dotnet/xliff-tasks"" xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006"" mc:Ignorable=""xliff"">
   <!-- DisplayName: My rule display name comment -->
   <!-- Description: My rule description comment -->
   <Rule.Categories>
@@ -138,6 +148,9 @@ namespace XliffTasks.Tests
   <BoolProperty Name=""MyBoolProperty"" Description=""III"" />
   <StringProperty Name=""MyStringProperty"">
     <StringProperty.Metadata>
+      <NameValuePair Name=""TypeDescriptorText"" Value=""KKK"" xliff:IsTranslatable=""true"">
+        <!-- Value: My type descriptor text comment -->
+      </NameValuePair>
       <NameValuePair Name=""SearchTerms"" Value=""JJJ"">
         <!-- Value: My search terms comment -->
       </NameValuePair>

--- a/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
+++ b/src/XliffTasks.Tests/XamlRuleDocumentTests.cs
@@ -39,10 +39,10 @@ namespace XliffTasks.Tests
   <BoolProperty Name=""MyBoolProperty"" Description=""My bool property description."" />
   <StringProperty Name=""MyStringProperty"">
     <StringProperty.Metadata>
-      <NameValuePair Name=""TypeDescriptorText"" Value=""Custom symbols"" xliff:IsTranslatable=""true"">
+      <NameValuePair Name=""TypeDescriptorText"" Value=""Custom symbols"" xliff:LocalizedProperties=""Value"">
         <!-- Value: My type descriptor text comment -->
       </NameValuePair>
-      <NameValuePair Name=""SearchTerms"" Value=""My;Search;Terms"">
+      <NameValuePair Name=""SearchTerms"" Value=""My;Search;Terms"" TranslatableProp1=""tr1"" TranslatableProp2=""tr2"" NonTranslatableProp3=""same"" xliff:LocalizedProperties=""TranslatableProp1;TranslatableProp2"">
         <!-- Value: My search terms comment -->
       </NameValuePair>
     </StringProperty.Metadata>
@@ -103,7 +103,17 @@ namespace XliffTasks.Tests
         <target state=""new"">My;Search;Terms</target>
         <note>My search terms comment</note>
       </trans-unit>
-      <trans-unit id=""StringProperty|MyStringProperty|Metadata|TypeDescriptorText"">
+      <trans-unit id=""StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp1"">
+        <source>tr1</source>
+        <target state=""new"">tr1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp2"">
+        <source>tr2</source>
+        <target state=""new"">tr2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id=""StringProperty|MyStringProperty|Metadata|TypeDescriptorText|Value"">
         <source>Custom symbols</source>
         <target state=""new"">Custom symbols</target>
         <note>My type descriptor text comment</note>
@@ -124,7 +134,9 @@ namespace XliffTasks.Tests
                 ["EnumValue|MyEnumProperty.Third|DisplayName"] = "HHH",
                 ["BoolProperty|MyBoolProperty|Description"] = "III",
                 ["StringProperty|MyStringProperty|Metadata|SearchTerms"] = "JJJ",
-                ["StringProperty|MyStringProperty|Metadata|TypeDescriptorText"] = "KKK",
+                ["StringProperty|MyStringProperty|Metadata|TypeDescriptorText|Value"] = "KKK",
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp1"] = "LLL",
+                ["StringProperty|MyStringProperty|Metadata|SearchTerms|TranslatableProp2"] = "MMM",
             };
 
             string expectedTranslation =
@@ -148,10 +160,10 @@ namespace XliffTasks.Tests
   <BoolProperty Name=""MyBoolProperty"" Description=""III"" />
   <StringProperty Name=""MyStringProperty"">
     <StringProperty.Metadata>
-      <NameValuePair Name=""TypeDescriptorText"" Value=""KKK"" xliff:IsTranslatable=""true"">
+      <NameValuePair Name=""TypeDescriptorText"" Value=""KKK"" xliff:LocalizedProperties=""Value"">
         <!-- Value: My type descriptor text comment -->
       </NameValuePair>
-      <NameValuePair Name=""SearchTerms"" Value=""JJJ"">
+      <NameValuePair Name=""SearchTerms"" Value=""JJJ"" TranslatableProp1=""LLL"" TranslatableProp2=""MMM"" NonTranslatableProp3=""same"" xliff:LocalizedProperties=""TranslatableProp1;TranslatableProp2"">
         <!-- Value: My search terms comment -->
       </NameValuePair>
     </StringProperty.Metadata>

--- a/src/XliffTasks/Model/XamlRuleDocument.cs
+++ b/src/XliffTasks/Model/XamlRuleDocument.cs
@@ -15,6 +15,9 @@ namespace XliffTasks.Model
     /// </summary>
     internal sealed class XamlRuleDocument : TranslatableXmlDocument
     {
+        private const string XliffTasksNs = "https://github.com/dotnet/xliff-tasks";
+        private const string IsTranslatableAttributeName = "IsTranslatable";
+        
         protected override IEnumerable<TranslatableNode> GetTranslatableNodes()
         {
             foreach (XElement? element in Document.Descendants())
@@ -30,8 +33,8 @@ namespace XliffTasks.Model
                             note: GetComment(element, XmlName(attribute)),
                             attribute: attribute);
                     }
-                    else if (XmlName(attribute) == "Value"
-                        && AttributedName(element) == "SearchTerms")
+                    else if (XmlName(attribute) == "Value" && 
+                             (AttributedName(element) == "SearchTerms" || (bool.TryParse(element.Attribute(XName.Get(IsTranslatableAttributeName, XliffTasksNs))?.Value, out var isTranslatable) && isTranslatable)))
                     {
                         yield return new TranslatableXmlAttribute(
                             id: GenerateIdForPropertyMetadata(element),


### PR DESCRIPTION
Currently, there is no ability to allow arbitrary values other than DisplayName, Description, or Value _where Name="SearchTerms"_. This PR relaxes the restriction on Value attributes not named `SearchTerms` to allow them to be marked as translatable if and only if a property named IsTranslatable, with a namespace corresponding to this repo's url (https://github.com/dotnet/xliff-tasks) is marked as true.

Ex:
This allows us to do:
```xaml
 <ValueEditor EditorType="MultiStringSelector">
        <ValueEditor.Metadata>
          <NameValuePair Name="TypeDescriptorText" Value="Custom symbols" xliff:IsTranslatable="true" />
          <NameValuePair Name="AllowsCustomStrings" Value="True" />
          <NameValuePair Name="ShouldDisplayEvaluatedPreview" Value="True" />
        </ValueEditor.Metadata>
      </ValueEditor>
```

where `TypeDescriptorText`'s value is localizable.

In conjunction w/ @drewnoakes 