### PR TITLE
Upgrade MSBuild package versions & use floating TFMs

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
       <Sha>fb14cae30eacbe844468ac297b3d4c61e0bb9dc0</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23120.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23214.4">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>cc8e05f07e9f9b4a2ab7db89a49b2167fcc3648f</Sha>
+      <Sha>05b4fdac346e01716abda4c92fcf0b7880e73792</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="8.0.0-beta.23211.2" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,6 @@
     <UsingToolXliff>false</UsingToolXliff>
     <!-- MSBuild
          Only update when there's a source-build package available. -->
-    <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
     <MicrosoftBuildUtilitiesCoreVersion>17.3.2</MicrosoftBuildUtilitiesCoreVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <UsingToolXliff>false</UsingToolXliff>
     <!-- MSBuild
          Only update when there's a source-build package available. -->
-    <MicrosoftBuildPackageVersion>15.1.1012</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>15.1.1012</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.3.2/MicrosoftBuildUtilitiesCoreVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,6 +6,6 @@
     <!-- MSBuild
          Only update when there's a source-build package available. -->
     <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>17.3.2/MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.3.2</MicrosoftBuildUtilitiesCoreVersion>
   </PropertyGroup>
 </Project>

--- a/src/XliffTasks.Tests/XliffTasks.Tests.csproj
+++ b/src/XliffTasks.Tests/XliffTasks.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/XliffTasks/XliffTasks.csproj
+++ b/src/XliffTasks/XliffTasks.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/XliffTasks/XliffTasks.csproj
+++ b/src/XliffTasks/XliffTasks.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
     <IsPackable>true</IsPackable>
     <!-- NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. -->
@@ -21,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
1. Upgrade MSBulid package versions to not bring in old netstandard1.x assets. Use the latest available version in SBRP.
2. Use the floating TFM versions defined in Arcade.
3. Consolidate version properties in Versions.props to "<PackageIdentity>Version" instead of the mix of the former and "<PackageIdentity>PackageVersion".