### PR TITLE
Remove redundant SourceBuildTrimNetFrameworkTargets property

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <GitHubRepositoryName>xliff-tasks</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Part of dotnet/source-build#3503