### PR TITLE
Revert "Update to 9.0 SDK and TFM"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,6 @@
 {
-  "sdk": {
-    "version": "9.0.100-alpha.1.23511.2",
-    "allowPrerelease": true,
-    "rollForward": "major"
-  },
   "tools": {
-    "dotnet": "9.0.100-alpha.1.23511.2"
+    "dotnet": "8.0.100-rtm.23506.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.23524.1"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,9 +11,4 @@
     <CheckForOverflowUnderflow Condition="'$(Configuration)' == 'Debug'">true</CheckForOverflowUnderflow>
   </PropertyGroup>
 
-  <!-- TODO: Remove when Arcades updates NetCurrent to net9.0. -->
-  <PropertyGroup>
-    <NetCurrent>net9.0</NetCurrent>
-  </PropertyGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.targets
+++ b/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.targets
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-    <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net9.0\</XliffTasksDirectory>
+    <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net8.0\</XliffTasksDirectory>
     <XliffTasksDirectory Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net462\</XliffTasksDirectory>
     <XliffTasksAssembly>$(XliffTasksDirectory)Microsoft.DotNet.XliffTasks.dll</XliffTasksAssembly>
   </PropertyGroup>


### PR DESCRIPTION
Reverts dotnet/xliff-tasks#836

Too soon. We can't do this before Arcade updates to a 9.0 SDK. Unblocks https://github.com/dotnet/arcade/pull/14159